### PR TITLE
feat: sección Racha Reciente con ventanas de 7, 15 y 30 días

### DIFF
--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -132,6 +132,115 @@ body {
   text-transform: uppercase;
 }
 
+/* ── RACHA RECIENTE ── */
+.racha-section {
+  background: linear-gradient(135deg, rgba(30, 41, 59, 0.85), rgba(17, 24, 39, 0.8));
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  backdrop-filter: blur(8px);
+  border-radius: 14px;
+  padding: 28px;
+  margin-bottom: 24px;
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);
+}
+
+.racha-section h2 {
+  font-size: 1.05em;
+  font-weight: 700;
+  color: #e2e8f0;
+  margin-bottom: 20px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  border-left: 3px solid #fb923c;
+  padding-left: 12px;
+}
+
+.racha-cards {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 16px;
+}
+
+.racha-card {
+  background: rgba(15, 23, 42, 0.55);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 10px;
+  padding: 18px 16px;
+  transition: border-color 0.2s, transform 0.2s;
+}
+
+.racha-card:hover {
+  border-color: rgba(251, 146, 60, 0.25);
+  transform: translateY(-3px);
+}
+
+.racha-card-title {
+  font-family: 'Roboto Mono', monospace;
+  font-size: 0.8em;
+  font-weight: 700;
+  color: #fb923c;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  margin-bottom: 16px;
+  text-align: center;
+}
+
+.racha-metrics {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.racha-metric {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.racha-metric-top {
+  display: flex;
+  align-items: baseline;
+  gap: 2px;
+}
+
+.racha-metric-value {
+  font-family: 'Roboto Mono', monospace;
+  font-size: 1.7em;
+  font-weight: 800;
+  line-height: 1;
+}
+
+.racha-metric-value.fill-pasos  { color: #34d399; }
+.racha-metric-value.fill-fuerza { color: #a78bfa; }
+.racha-metric-value.fill-cardio { color: #00d4ff; }
+
+.racha-metric-total {
+  font-family: 'Roboto Mono', monospace;
+  font-size: 0.8em;
+  color: #4b5563;
+}
+
+.racha-metric-label {
+  font-size: 0.72em;
+  color: #6b7280;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.racha-bar {
+  height: 4px;
+  background: rgba(255, 255, 255, 0.06);
+  border-radius: 2px;
+  overflow: hidden;
+  margin-top: 2px;
+}
+
+.racha-fill {
+  height: 100%;
+  border-radius: 2px;
+  transition: width 0.5s ease;
+}
+
 /* ── CHARTS ── */
 .charts-section {
   display: flex;
@@ -588,6 +697,10 @@ canvas {
 
   .stats-grid {
     grid-template-columns: repeat(2, 1fr);
+  }
+
+  .racha-cards {
+    grid-template-columns: 1fr;
   }
 
   .week-table {

--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -219,6 +219,13 @@ body {
   color: #4b5563;
 }
 
+.racha-metric-pct {
+  font-family: 'Roboto Mono', monospace;
+  font-size: 0.75em;
+  color: #6b7280;
+  margin-left: auto;
+}
+
 .racha-metric-label {
   font-size: 0.72em;
   color: #6b7280;

--- a/docs/index.html
+++ b/docs/index.html
@@ -42,6 +42,11 @@
       </div>
     </section>
 
+    <section class="racha-section">
+      <h2>Racha reciente</h2>
+      <div class="racha-cards" id="rachaCards"></div>
+    </section>
+
     <section class="charts-section">
       <div class="chart-container">
         <h2>Historial de entrenamiento</h2>

--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -80,6 +80,7 @@ function renderRachas() {
           <div class="racha-metric-top">
             <span class="racha-metric-value ${cls}">${valor}</span>
             <span class="racha-metric-total">/${dias}</span>
+            <span class="racha-metric-pct">${pct}%</span>
           </div>
           <div class="racha-metric-label">${label}</div>
           <div class="racha-bar">

--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -46,6 +46,9 @@ function renderDashboard() {
   document.getElementById('diasPasos').textContent = stats.diasPasos;
   document.getElementById('promedioPasos').textContent = stats.promedioPasos.toLocaleString('es-MX');
 
+  // Racha reciente
+  renderRachas();
+
   // Resumen semanal
   renderWeeklySummary();
 
@@ -54,6 +57,47 @@ function renderDashboard() {
 
   // Gráficos
   renderCharts();
+}
+
+function renderRachas() {
+  const container = document.getElementById('rachaCards');
+  if (!container || !dashboardData.rachas) return;
+
+  const ventanas = [
+    dashboardData.rachas.d7,
+    dashboardData.rachas.d15,
+    dashboardData.rachas.d30,
+  ];
+
+  container.innerHTML = ventanas.map(v => {
+    const pctPasos  = Math.round((v.pasos  / v.dias) * 100);
+    const pctFuerza = Math.round((v.fuerza / v.dias) * 100);
+    const pctCardio = Math.round((v.cardio / v.dias) * 100);
+
+    function metrica(valor, dias, pct, cls, label) {
+      return `
+        <div class="racha-metric">
+          <div class="racha-metric-top">
+            <span class="racha-metric-value ${cls}">${valor}</span>
+            <span class="racha-metric-total">/${dias}</span>
+          </div>
+          <div class="racha-metric-label">${label}</div>
+          <div class="racha-bar">
+            <div class="racha-fill ${cls}" style="width:${pct}%"></div>
+          </div>
+        </div>`;
+    }
+
+    return `
+      <div class="racha-card">
+        <div class="racha-card-title">${v.dias} días</div>
+        <div class="racha-metrics">
+          ${metrica(v.pasos,  v.dias, pctPasos,  'fill-pasos',  'Pasos 10k')}
+          ${metrica(v.fuerza, v.dias, pctFuerza, 'fill-fuerza', 'Fuerza')}
+          ${metrica(v.cardio, v.dias, pctCardio, 'fill-cardio', 'Cardio')}
+        </div>
+      </div>`;
+  }).join('');
 }
 
 function renderWeekTable() {

--- a/scripts/fetch-notion-data.js
+++ b/scripts/fetch-notion-data.js
@@ -208,6 +208,29 @@ async function fetchData() {
 
     const hoyStr = hoy.toISOString().split('T')[0];
 
+    function calcVentana(n) {
+      const corte = new Date(hoy);
+      corte.setDate(hoy.getDate() - (n - 1));
+      const corteStr = corte.toISOString().split('T')[0];
+      const ventana = todosLosDias.filter(d => d.fecha >= corteStr && d.fecha <= hoyStr);
+      return {
+        dias: n,
+        pasos: ventana.filter(d => d.cumplePasos).length,
+        fuerza: ventana.filter(d =>
+          d.disciplinas.includes('Fuerza') || d.disciplinas.includes('Mixto')
+        ).length,
+        cardio: ventana.filter(d =>
+          d.disciplinas.some(disc => CARDIO_DISC.includes(disc)) || d.disciplinas.includes('Mixto')
+        ).length,
+      };
+    }
+
+    const rachas = {
+      d7:  calcVentana(7),
+      d15: calcVentana(15),
+      d30: calcVentana(30),
+    };
+
     const semanas = Object.values(semanaMap)
       .sort((a, b) => a.inicio.localeCompare(b.inicio))
       .map(({ inicio, dias }) => {
@@ -263,6 +286,7 @@ async function fetchData() {
     const salida = {
       actualizado: new Date().toISOString(),
       stats,
+      rachas,
       distribucionDisciplinas,
       ultimos30,
       todosLosDias,


### PR DESCRIPTION
## Cambios

- Nueva sección **Racha Reciente** entre las stats principales y los gráficos
- 3 tarjetas (7, 15, 30 días) mostrando para cada ventana:
  - Días con 10k+ pasos (verde)
  - Sesiones de fuerza (morado)
  - Sesiones de cardio (cyan)
- Cada métrica muestra conteo, porcentaje y barra de progreso
- Cálculos generados en `fetch-notion-data.js` y guardados en `data.json`
- Responsive: columna única en móvil

https://claude.ai/code/session_01QUVxVrajjC7qwZ4pETVW4X

---
_Generated by [Claude Code](https://claude.ai/code/session_01QUVxVrajjC7qwZ4pETVW4X)_