### PR TITLE
feat: refactorizar charts.js, insight cards y ESLint + Prettier

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,7 @@
+{
+  "singleQuote": true,
+  "semi": true,
+  "tabWidth": 2,
+  "trailingComma": "es5",
+  "printWidth": 100
+}

--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -132,6 +132,79 @@ body {
   text-transform: uppercase;
 }
 
+/* ── INSIGHTS ── */
+.insights-section {
+  background: linear-gradient(135deg, rgba(30, 41, 59, 0.85), rgba(17, 24, 39, 0.8));
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  backdrop-filter: blur(8px);
+  border-radius: 14px;
+  padding: 28px;
+  margin-bottom: 24px;
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);
+}
+
+.insights-section h2 {
+  font-size: 1.05em;
+  font-weight: 700;
+  color: #e2e8f0;
+  margin-bottom: 20px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  border-left: 3px solid #a78bfa;
+  padding-left: 12px;
+}
+
+.insights-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+  gap: 12px;
+}
+
+.insight-card {
+  display: flex;
+  align-items: flex-start;
+  gap: 14px;
+  background: rgba(15, 23, 42, 0.55);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 10px;
+  padding: 16px;
+  transition: transform 0.2s, border-color 0.2s;
+}
+
+.insight-card:hover {
+  transform: translateY(-2px);
+}
+
+.insight-card.insight-positive { border-left: 3px solid #34d399; }
+.insight-card.insight-warning  { border-left: 3px solid #fb923c; }
+.insight-card.insight-neutral  { border-left: 3px solid #64748b; }
+
+.insight-icon {
+  font-size: 1.6em;
+  line-height: 1;
+  flex-shrink: 0;
+  margin-top: 2px;
+}
+
+.insight-body {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.insight-title {
+  font-family: 'Roboto Mono', monospace;
+  font-size: 0.88em;
+  font-weight: 700;
+  color: #e2e8f0;
+}
+
+.insight-desc {
+  font-size: 0.78em;
+  color: #6b7280;
+  line-height: 1.4;
+}
+
 /* ── RACHA RECIENTE ── */
 .racha-section {
   background: linear-gradient(135deg, rgba(30, 41, 59, 0.85), rgba(17, 24, 39, 0.8));

--- a/docs/index.html
+++ b/docs/index.html
@@ -42,6 +42,11 @@
       </div>
     </section>
 
+    <section class="insights-section">
+      <h2>Insights</h2>
+      <div class="insights-grid" id="insightsGrid"></div>
+    </section>
+
     <section class="racha-section">
       <h2>Racha reciente</h2>
       <div class="racha-cards" id="rachaCards"></div>

--- a/docs/js/charts.js
+++ b/docs/js/charts.js
@@ -1,2 +1,261 @@
-// Los gráficos se renderizan en main.js
-// Este archivo está reservado para funciones adicionales de gráficos si es necesario
+/* global dashboardData */
+/* exported renderCharts, renderHeatmap, renderPieChart, renderTrendChart */
+
+function renderCharts() {
+  renderHeatmap();
+  renderPieChart();
+  renderTrendChart();
+}
+
+function renderTrendChart() {
+  const ctx = document.getElementById('trendChart');
+  if (!ctx || !dashboardData.todosDatos) return;
+
+  const todosLosDatos = dashboardData.todosDatos;
+  const labels = todosLosDatos.map(d => {
+    const date = new Date(d.fecha + 'T00:00:00');
+    return date.toLocaleDateString('es-MX', { day: 'numeric', month: 'short' });
+  });
+  const data = todosLosDatos.map(d => d.pasos);
+
+  new Chart(ctx.getContext('2d'), {
+    type: 'line',
+    data: {
+      labels,
+      datasets: [
+        {
+          label: 'Pasos diarios',
+          data,
+          borderColor: '#00d4ff',
+          backgroundColor: 'rgba(0, 212, 255, 0.05)',
+          fill: true,
+          tension: 0.2,
+          pointRadius: todosLosDatos.length > 60 ? 1 : 3,
+          pointHoverRadius: 6,
+          borderWidth: 2,
+          pointBackgroundColor: '#00d4ff',
+        },
+        {
+          label: 'Meta (10k)',
+          data: Array(labels.length).fill(10000),
+          borderColor: 'rgba(52, 211, 153, 0.4)',
+          borderDash: [5, 5],
+          fill: false,
+          pointRadius: 0,
+          borderWidth: 1.5,
+        },
+      ],
+    },
+    options: {
+      responsive: true,
+      maintainAspectRatio: false,
+      interaction: { mode: 'index', intersect: false },
+      plugins: {
+        legend: {
+          display: true,
+          position: 'top',
+          labels: { color: '#9ca3af', boxWidth: 20, font: { size: 11 } },
+        },
+        tooltip: {
+          backgroundColor: 'rgba(15, 23, 42, 0.9)',
+          padding: 12,
+          callbacks: {
+            label(context) {
+              const val = context.parsed.y;
+              return `${context.dataset.label}: ${val ? val.toLocaleString('es-MX') : 0}`;
+            },
+          },
+        },
+      },
+      scales: {
+        y: {
+          beginAtZero: true,
+          grid: { color: 'rgba(255, 255, 255, 0.05)' },
+          ticks: {
+            color: '#64748b',
+            callback(value) {
+              return value >= 1000 ? value / 1000 + 'k' : value;
+            },
+          },
+        },
+        x: {
+          grid: { display: false },
+          ticks: { color: '#64748b', maxRotation: 45, minRotation: 45, autoSkip: true, maxTicksLimit: 15 },
+        },
+      },
+    },
+  });
+}
+
+function renderHeatmap() {
+  const container = document.getElementById('heatmap');
+  container.innerHTML = '';
+
+  const colorMap = {
+    verde: '#34d399',
+    amarillo: '#fb923c',
+    rojo: '#f87171',
+    gris: '#1e293b',
+    futuro: 'transparent',
+  };
+  const estadoLabel = { verde: 'Verde', amarillo: 'Naranja', rojo: 'Rojo', gris: 'Sin datos', futuro: 'Próximamente' };
+  const MONTHS = ['Ene', 'Feb', 'Mar', 'Abr', 'May', 'Jun', 'Jul', 'Ago', 'Sep', 'Oct', 'Nov', 'Dic'];
+
+  const hoy = new Date();
+  const startYear = new Date('2025-12-29T00:00:00');
+  const endYear = new Date(2026, 11, 31, 23, 59, 59);
+
+  const diasMap = Object.fromEntries(dashboardData.todosLosDias.map(d => [d.fecha, d]));
+
+  const diasCompletos = [];
+  for (let d = new Date(startYear); d <= endYear; d.setDate(d.getDate() + 1)) {
+    const fStr = d.toISOString().split('T')[0];
+    if (diasMap[fStr]) {
+      const dia = { ...diasMap[fStr] };
+      if (d > hoy) dia.estado = 'futuro';
+      diasCompletos.push(dia);
+    } else {
+      diasCompletos.push({ fecha: fStr, estado: d > hoy ? 'futuro' : 'gris', pasos: 0, disciplinas: [], duracion: 0 });
+    }
+  }
+
+  const startPad = (startYear.getDay() + 6) % 7;
+  const cells = [...Array(startPad).fill(null), ...diasCompletos];
+  const totalWeeks = Math.ceil(cells.length / 7);
+
+  const monthRow = document.createElement('div');
+  monthRow.className = 'heatmap-months';
+
+  let lastMonth = -1;
+  for (let w = 0; w < totalWeeks; w++) {
+    const span = document.createElement('span');
+    for (let r = 0; r < 7; r++) {
+      const c = cells[w * 7 + r];
+      if (c) {
+        const m = new Date(c.fecha + 'T00:00:00').getMonth();
+        if (m !== lastMonth) {
+          span.textContent = MONTHS[m];
+          lastMonth = m;
+        }
+        break;
+      }
+    }
+    monthRow.appendChild(span);
+  }
+
+  const gridRow = document.createElement('div');
+  gridRow.className = 'heatmap-grid-row';
+
+  const dayLabels = document.createElement('div');
+  dayLabels.className = 'heatmap-day-labels';
+  ['L', 'M', 'X', 'J', 'V', 'S', 'D'].forEach(lbl => {
+    const el = document.createElement('span');
+    el.textContent = lbl;
+    dayLabels.appendChild(el);
+  });
+
+  const grid = document.createElement('div');
+  grid.className = 'heatmap-grid';
+
+  let tip = document.getElementById('heatmap-tip');
+  if (!tip) {
+    tip = document.createElement('div');
+    tip.id = 'heatmap-tip';
+    tip.className = 'heatmap-tooltip';
+    document.body.appendChild(tip);
+  }
+
+  function moveTip(e) {
+    tip.style.left = e.clientX + 14 + 'px';
+    tip.style.top = e.clientY - 10 + 'px';
+  }
+
+  cells.forEach(dia => {
+    const cell = document.createElement('div');
+    cell.className = 'heatmap-cell';
+
+    if (dia) {
+      if (dia.estado === 'futuro') cell.classList.add('futuro');
+
+      const color = colorMap[dia.estado];
+      cell.style.background = color;
+      if (dia.estado !== 'gris' && dia.estado !== 'futuro') {
+        cell.style.boxShadow = `0 0 5px ${color}55`;
+      }
+
+      cell.addEventListener('mouseenter', e => {
+        tip.innerHTML =
+          `<div class="tt-date">${dia.fecha}</div>` +
+          `<div class="tt-row">Estado: <strong>${estadoLabel[dia.estado]}</strong></div>` +
+          (dia.pasos > 0 ? `<div class="tt-row">Pasos: <strong>${dia.pasos.toLocaleString()}</strong></div>` : '') +
+          (dia.disciplinaPrincipal ? `<div class="tt-row">Disciplina: <strong>${dia.disciplinaPrincipal}</strong></div>` : '') +
+          (dia.duracion ? `<div class="tt-row">Duración: <strong>${dia.duracion} min</strong></div>` : '');
+        tip.classList.add('visible');
+        moveTip(e);
+      });
+      cell.addEventListener('mousemove', moveTip);
+      cell.addEventListener('mouseleave', () => tip.classList.remove('visible'));
+    } else {
+      cell.style.background = 'transparent';
+      cell.style.pointerEvents = 'none';
+    }
+    grid.appendChild(cell);
+  });
+
+  gridRow.appendChild(dayLabels);
+  gridRow.appendChild(grid);
+  container.appendChild(monthRow);
+  container.appendChild(gridRow);
+}
+
+function renderPieChart() {
+  const ctx = document.getElementById('pieChart').getContext('2d');
+  const disciplinas = dashboardData.distribucionDisciplinas;
+  const labels = disciplinas.map(d => `${d.nombre}: ${d.count} (${d.porcentaje}%)`);
+  const data = disciplinas.map(d => d.count);
+  const colores = ['#00d4ff', '#34d399', '#a78bfa', '#fbbf24', '#f87171', '#fb923c'];
+
+  new Chart(ctx, {
+    type: 'doughnut',
+    data: {
+      labels,
+      datasets: [
+        {
+          data,
+          backgroundColor: colores.slice(0, data.length),
+          borderColor: 'rgba(15, 23, 42, 0.9)',
+          borderWidth: 2,
+        },
+      ],
+    },
+    options: {
+      responsive: true,
+      maintainAspectRatio: true,
+      plugins: {
+        legend: {
+          position: 'bottom',
+          labels: {
+            padding: 16,
+            color: '#9ca3af',
+            font: { family: 'Roboto', size: 12 },
+            usePointStyle: true,
+            pointStyleWidth: 10,
+          },
+        },
+        tooltip: {
+          backgroundColor: 'rgba(15, 23, 42, 0.95)',
+          titleColor: '#00d4ff',
+          bodyColor: '#cbd5e1',
+          borderColor: 'rgba(0, 212, 255, 0.2)',
+          borderWidth: 1,
+          padding: 12,
+          callbacks: {
+            label(context) {
+              return `${context.label}: ${context.parsed} sesiones`;
+            },
+          },
+        },
+      },
+    },
+  });
+}

--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -1,3 +1,5 @@
+/* global renderCharts */
+
 let dashboardData = null;
 
 async function loadData() {
@@ -45,6 +47,9 @@ function renderDashboard() {
   document.getElementById('diasEjercicio').textContent = stats.diasEjercicio;
   document.getElementById('diasPasos').textContent = stats.diasPasos;
   document.getElementById('promedioPasos').textContent = stats.promedioPasos.toLocaleString('es-MX');
+
+  // Insights automáticos
+  renderInsights();
 
   // Racha reciente
   renderRachas();
@@ -108,7 +113,7 @@ function renderWeekTable() {
   const diasNombre = ['Domingo', 'Lunes', 'Martes', 'Miércoles', 'Jueves', 'Viernes', 'Sábado'];
   const porDiaSemana = dashboardData.porDiaSemana;
 
-  diasNombre.forEach((dia, idx) => {
+  diasNombre.forEach((dia, _idx) => {
     const stats = porDiaSemana[dia.substring(0, 3)] || { total: 0, ejercicio: 0, pasos: 0, verdes: 0 };
     
     const pctEjercicio = stats.total > 0 ? Math.round((stats.ejercicio / stats.total) * 100) : 0;
@@ -222,300 +227,94 @@ function renderWeeklySummary() {
   }).join('');
 }
 
-function renderCharts() {
-  renderHeatmap();
-  renderPieChart();
-  renderTrendChart();
+function computeInsights() {
+  const datos = dashboardData.todosDatos;
+  const hoy = new Date().toISOString().split('T')[0];
+  const sorted = [...datos].sort((a, b) => b.fecha.localeCompare(a.fecha));
+
+  let racha = 0;
+  for (const d of sorted) {
+    if (d.fecha > hoy) continue;
+    if (d.estado === 'verde' || d.estado === 'amarillo') racha++;
+    else break;
+  }
+
+  const CARDIO = ['Natación', 'Carrera', 'Bici', 'Mixto'];
+  const ultimoCardio = sorted.find(d => d.fecha <= hoy && d.disciplinas.some(disc => CARDIO.includes(disc)));
+  const diasSinCardio = ultimoCardio
+    ? Math.round((new Date(hoy) - new Date(ultimoCardio.fecha)) / 86400000)
+    : null;
+
+  const ultimoFuerza = sorted.find(d => d.fecha <= hoy && (d.disciplinas.includes('Fuerza') || d.disciplinas.includes('Mixto')));
+  const diasSinFuerza = ultimoFuerza
+    ? Math.round((new Date(hoy) - new Date(ultimoFuerza.fecha)) / 86400000)
+    : null;
+
+  const hace7 = new Date();
+  hace7.setDate(hace7.getDate() - 6);
+  const hace7Str = hace7.toISOString().split('T')[0];
+  const ultimos7 = datos.filter(d => d.fecha >= hace7Str && d.fecha <= hoy && d.pasos > 0);
+  const promedioUltimos7 = ultimos7.length
+    ? Math.round(ultimos7.reduce((s, d) => s + d.pasos, 0) / ultimos7.length)
+    : 0;
+  const diffPasos = dashboardData.stats.promedioPasos > 0
+    ? Math.round(((promedioUltimos7 - dashboardData.stats.promedioPasos) / dashboardData.stats.promedioPasos) * 100)
+    : 0;
+
+  return { racha, diasSinCardio, diasSinFuerza, promedioUltimos7, diffPasos };
 }
 
-function renderTrendChart() {
-  const ctx = document.getElementById('trendChart');
-  if (!ctx || !dashboardData.todosDatos) return;
-  
-  const todosLosDatos = dashboardData.todosDatos;
-  const labels = todosLosDatos.map(d => {
-    const date = new Date(d.fecha + 'T00:00:00');
-    return date.toLocaleDateString('es-MX', { day: 'numeric', month: 'short' });
-  });
-  const data = todosLosDatos.map(d => d.pasos);
+function renderInsights() {
+  const container = document.getElementById('insightsGrid');
+  if (!container) return;
 
-  new Chart(ctx.getContext('2d'), {
-    type: 'line',
-    data: {
-      labels,
-      datasets: [
-        {
-          label: 'Pasos diarios',
-          data,
-          borderColor: '#00d4ff',
-          backgroundColor: 'rgba(0, 212, 255, 0.05)',
-          fill: true,
-          tension: 0.2,
-          pointRadius: todosLosDatos.length > 60 ? 1 : 3,
-          pointHoverRadius: 6,
-          borderWidth: 2,
-          pointBackgroundColor: '#00d4ff',
-        },
-        {
-          label: 'Meta (10k)',
-          data: Array(labels.length).fill(10000),
-          borderColor: 'rgba(52, 211, 153, 0.4)',
-          borderDash: [5, 5],
-          fill: false,
-          pointRadius: 0,
-          borderWidth: 1.5,
-        }
-      ]
-    },
-    options: {
-      responsive: true,
-      maintainAspectRatio: false,
-      interaction: {
-        mode: 'index',
-        intersect: false,
-      },
-      plugins: {
-        legend: {
-          display: true,
-          position: 'top',
-          labels: { 
-            color: '#9ca3af',
-            boxWidth: 20,
-            font: { size: 11 }
-          }
-        },
-        tooltip: {
-          backgroundColor: 'rgba(15, 23, 42, 0.9)',
-          padding: 12,
-          callbacks: {
-            label: function(context) {
-              const val = context.parsed.y;
-              return `${context.dataset.label}: ${val ? val.toLocaleString('es-MX') : 0}`;
-            }
-          }
-        }
-      },
-      scales: {
-        y: {
-          beginAtZero: true,
-          grid: { color: 'rgba(255, 255, 255, 0.05)' },
-          ticks: { 
-            color: '#64748b',
-            callback: function(value) {
-              return value >= 1000 ? (value / 1000) + 'k' : value;
-            }
-          }
-        },
-        x: {
-          grid: { display: false },
-          ticks: { 
-            color: '#64748b',
-            maxRotation: 45,
-            minRotation: 45,
-            autoSkip: true,
-            maxTicksLimit: 15
-          }
-        }
-      }
-    }
-  });
-}
+  const { racha, diasSinCardio, diasSinFuerza, promedioUltimos7, diffPasos } = computeInsights();
+  const insights = [];
 
-function renderHeatmap() {
-  const container = document.getElementById('heatmap');
-  container.innerHTML = '';
+  if (racha >= 2) {
+    insights.push({ icon: '🔥', title: `${racha} días seguidos`, desc: `Llevas ${racha} días consecutivos cumpliendo el objetivo.`, type: 'positive' });
+  } else {
+    insights.push({ icon: '⚠️', title: 'Sin racha activa', desc: 'No hay cumplimiento consecutivo registrado. ¡Momento de retomar!', type: 'warning' });
+  }
 
-  const colorMap = {
-    verde:   '#34d399',
-    amarillo: '#fb923c',
-    rojo:    '#f87171',
-    gris:    '#1e293b',
-    futuro:  'transparent'
-  };
-  const estadoLabel = { verde: 'Verde', amarillo: 'Naranja', rojo: 'Rojo', gris: 'Sin datos', futuro: 'Próximamente' };
-  const MONTHS = ['Ene','Feb','Mar','Abr','May','Jun','Jul','Ago','Sep','Oct','Nov','Dic'];
-
-  const hoy = new Date();
-  
-  // Iniciar exactamente el 29 de diciembre de 2025
-  const startYear = new Date('2025-12-29T00:00:00');
-  // Terminar al final del 2026
-  const endYear = new Date(2026, 11, 31, 23, 59, 59);
-  
-  const diasMap = Object.fromEntries(dashboardData.todosLosDias.map(d => [d.fecha, d]));
-  
-  const diasCompletos = [];
-  for (let d = new Date(startYear); d <= endYear; d.setDate(d.getDate() + 1)) {
-    const fStr = d.toISOString().split('T')[0];
-    if (diasMap[fStr]) {
-      // Si el día está en el mapa pero es después de hoy, forzamos estado futuro
-      const dia = {...diasMap[fStr]};
-      if (d > hoy) dia.estado = 'futuro';
-      diasCompletos.push(dia);
+  if (diasSinCardio !== null) {
+    if (diasSinCardio === 0) {
+      insights.push({ icon: '🏊', title: 'Cardio hoy', desc: 'Hiciste cardio hoy.', type: 'positive' });
+    } else if (diasSinCardio > 4) {
+      insights.push({ icon: '🏊', title: `${diasSinCardio} días sin cardio`, desc: `La última sesión de cardio fue hace ${diasSinCardio} días.`, type: 'warning' });
     } else {
-      diasCompletos.push({
-        fecha: fStr,
-        estado: d > hoy ? 'futuro' : 'gris',
-        pasos: 0, disciplinas: [], duracion: 0
-      });
+      insights.push({ icon: '🏊', title: `Cardio hace ${diasSinCardio}d`, desc: `Última sesión de cardio hace ${diasSinCardio} día${diasSinCardio > 1 ? 's' : ''}.`, type: 'neutral' });
     }
   }
 
-  // Pad start so first day aligns to its day-of-week (Mon = row 0)
-  const startPad  = (startYear.getDay() + 6) % 7;
-  const cells     = [...Array(startPad).fill(null), ...diasCompletos];
-  const totalWeeks = Math.ceil(cells.length / 7);
-
-  // ── Month labels ──────────────────────────────────────────
-  const monthRow = document.createElement('div');
-  monthRow.className = 'heatmap-months';
-
-  let lastMonth = -1;
-  for (let w = 0; w < totalWeeks; w++) {
-    const span = document.createElement('span');
-    for (let r = 0; r < 7; r++) {
-      const c = cells[w * 7 + r];
-      if (c) {
-        const m = new Date(c.fecha + 'T00:00:00').getMonth();
-        if (m !== lastMonth) { 
-          span.textContent = MONTHS[m]; 
-          lastMonth = m; 
-        }
-        break;
-      }
-    }
-    monthRow.appendChild(span);
-  }
-
-  // ── Grid row (day labels + cells) ────────────────────────
-  const gridRow = document.createElement('div');
-  gridRow.className = 'heatmap-grid-row';
-
-  const dayLabels = document.createElement('div');
-  dayLabels.className = 'heatmap-day-labels';
-  ['L','M','X','J','V','S','D'].forEach(lbl => {
-    const el = document.createElement('span');
-    el.textContent = lbl;
-    dayLabels.appendChild(el);
-  });
-
-  const grid = document.createElement('div');
-  grid.className = 'heatmap-grid';
-
-  // Shared tooltip
-  let tip = document.getElementById('heatmap-tip');
-  if (!tip) {
-    tip = document.createElement('div');
-    tip.id = 'heatmap-tip';
-    tip.className = 'heatmap-tooltip';
-    document.body.appendChild(tip);
-  }
-
-  cells.forEach(dia => {
-    const cell = document.createElement('div');
-    cell.className = 'heatmap-cell';
-
-    if (dia) {
-      if (dia.estado === 'futuro') {
-        cell.classList.add('futuro');
-      }
-      
-      const color = colorMap[dia.estado];
-      cell.style.background = color;
-      
-      if (dia.estado !== 'gris' && dia.estado !== 'futuro') {
-        cell.style.boxShadow = `0 0 5px ${color}55`;
-      }
-
-      cell.addEventListener('mouseenter', e => {
-        tip.innerHTML =
-          `<div class="tt-date">${dia.fecha}</div>` +
-          `<div class="tt-row">Estado: <strong>${estadoLabel[dia.estado]}</strong></div>` +
-          (dia.pasos > 0 ? `<div class="tt-row">Pasos: <strong>${dia.pasos.toLocaleString()}</strong></div>` : '') +
-          (dia.disciplinaPrincipal ? `<div class="tt-row">Disciplina: <strong>${dia.disciplinaPrincipal}</strong></div>` : '') +
-          (dia.duracion ? `<div class="tt-row">Duración: <strong>${dia.duracion} min</strong></div>` : '');
-        tip.classList.add('visible');
-        moveTip(e);
-      });
-      cell.addEventListener('mousemove', moveTip);
-      cell.addEventListener('mouseleave', () => tip.classList.remove('visible'));
+  if (diasSinFuerza !== null) {
+    if (diasSinFuerza === 0) {
+      insights.push({ icon: '💪', title: 'Fuerza hoy', desc: 'Hiciste una sesión de fuerza hoy.', type: 'positive' });
+    } else if (diasSinFuerza > 3) {
+      insights.push({ icon: '💪', title: `${diasSinFuerza} días sin fuerza`, desc: `La última sesión de fuerza fue hace ${diasSinFuerza} días.`, type: 'warning' });
     } else {
-      cell.style.background = 'transparent';
-      cell.style.pointerEvents = 'none';
+      insights.push({ icon: '💪', title: `Fuerza hace ${diasSinFuerza}d`, desc: `Última sesión de fuerza hace ${diasSinFuerza} día${diasSinFuerza > 1 ? 's' : ''}.`, type: 'neutral' });
     }
-    grid.appendChild(cell);
-  });
-
-  function moveTip(e) {
-    tip.style.left = (e.clientX + 14) + 'px';
-    tip.style.top  = (e.clientY - 10) + 'px';
   }
 
-  gridRow.appendChild(dayLabels);
-  gridRow.appendChild(grid);
-  container.appendChild(monthRow);
-  container.appendChild(gridRow);
-}
+  if (promedioUltimos7 > 0) {
+    const signo = diffPasos >= 0 ? '+' : '';
+    insights.push({
+      icon: '👟',
+      title: `${promedioUltimos7.toLocaleString('es-MX')} pasos/día`,
+      desc: `Promedio últimos 7 días: ${signo}${diffPasos}% vs. tu media general (${dashboardData.stats.promedioPasos.toLocaleString('es-MX')}).`,
+      type: diffPasos >= 0 ? 'positive' : 'warning',
+    });
+  }
 
-function renderPieChart() {
-  const ctx = document.getElementById('pieChart').getContext('2d');
-
-  const disciplinas = dashboardData.distribucionDisciplinas;
-  const labels = disciplinas.map(d => `${d.nombre}: ${d.count} (${d.porcentaje}%)`);
-  const data = disciplinas.map(d => d.count);
-
-  const colores = [
-    '#00d4ff',
-    '#34d399',
-    '#a78bfa',
-    '#fbbf24',
-    '#f87171',
-    '#fb923c',
-  ];
-
-  new Chart(ctx, {
-    type: 'doughnut',
-    data: {
-      labels,
-      datasets: [
-        {
-          data,
-          backgroundColor: colores.slice(0, data.length),
-          borderColor: 'rgba(15, 23, 42, 0.9)',
-          borderWidth: 2,
-        },
-      ],
-    },
-    options: {
-      responsive: true,
-      maintainAspectRatio: true,
-      plugins: {
-        legend: {
-          position: 'bottom',
-          labels: {
-            padding: 16,
-            color: '#9ca3af',
-            font: { family: 'Roboto', size: 12 },
-            usePointStyle: true,
-            pointStyleWidth: 10,
-          },
-        },
-        tooltip: {
-          backgroundColor: 'rgba(15, 23, 42, 0.95)',
-          titleColor: '#00d4ff',
-          bodyColor: '#cbd5e1',
-          borderColor: 'rgba(0, 212, 255, 0.2)',
-          borderWidth: 1,
-          padding: 12,
-          callbacks: {
-            label: function(context) {
-              return `${context.label}: ${context.parsed} sesiones`;
-            },
-          },
-        },
-      },
-    },
-  });
+  container.innerHTML = insights.map(ins => `
+    <div class="insight-card insight-${ins.type}">
+      <span class="insight-icon">${ins.icon}</span>
+      <div class="insight-body">
+        <div class="insight-title">${ins.title}</div>
+        <div class="insight-desc">${ins.desc}</div>
+      </div>
+    </div>`).join('');
 }
 
 // Cargar datos al iniciar

--- a/docs/sw.js
+++ b/docs/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'bitacora-v1';
+const CACHE_NAME = 'bitacora-v2';
 
 const STATIC_ASSETS = [
   '/bitacora-entrenamiento/',

--- a/docs/sw.js
+++ b/docs/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'bitacora-v2';
+const CACHE_NAME = 'bitacora-v3';
 
 const STATIC_ASSETS = [
   '/bitacora-entrenamiento/',

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,34 @@
+import globals from 'globals';
+import js from '@eslint/js';
+
+export default [
+  js.configs.recommended,
+  {
+    files: ['scripts/**/*.js'],
+    languageOptions: {
+      globals: globals.node,
+      ecmaVersion: 2022,
+      sourceType: 'commonjs',
+    },
+    rules: {
+      'no-console': 'off',
+      'prefer-const': 'error',
+    },
+  },
+  {
+    files: ['docs/js/**/*.js'],
+    languageOptions: {
+      globals: {
+        ...globals.browser,
+        Chart: 'readonly',
+      },
+      ecmaVersion: 2022,
+      sourceType: 'script',
+    },
+    rules: {
+      'no-console': 'warn',
+      'prefer-const': 'error',
+      'no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
+    },
+  },
+];

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,206 @@
         "dotenv": "^16.3.1"
       },
       "devDependencies": {
-        "http-server": "^14.1.1"
+        "@eslint/js": "^10.0.1",
+        "eslint": "^10.3.0",
+        "eslint-config-prettier": "^10.1.8",
+        "globals": "^17.6.0",
+        "http-server": "^14.1.1",
+        "prettier": "^3.8.3"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/config-array": {
+      "version": "0.23.5",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.5.tgz",
+      "integrity": "sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/object-schema": "^3.0.5",
+        "debug": "^4.3.1",
+        "minimatch": "^10.2.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.5.5.tgz",
+      "integrity": "sha512-eIJYKTCECbP/nsKaaruF6LW967mtbQbsw4JTtSVkUQc9MneSkbrgPJAbKl9nWr0ZeowV8BfsarBmPpBzGelA2w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^1.2.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.2.1.tgz",
+      "integrity": "sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-10.0.1.tgz",
+      "integrity": "sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "eslint": "^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "eslint": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@eslint/object-schema": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.5.tgz",
+      "integrity": "sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.1.tgz",
+      "integrity": "sha512-rZAP3aVgB9ds9KOeUSL+zZ21hPmo8dh6fnIFwRQj5EAZl9gzR7wxYbYXYysAM8CTqGmUGyp2S4kUdV17MnGuWQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^1.2.1",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@humanfs/core": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+      "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/types": "^0.15.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+      "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/core": "^0.19.2",
+        "@humanfs/types": "^0.15.0",
+        "@humanwhocodes/retry": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/types": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+      "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
       }
     },
     "node_modules/@notionhq/client": {
@@ -28,6 +227,27 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/@types/esrecurse": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
+      "integrity": "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/node": {
       "version": "25.6.0",
@@ -46,6 +266,46 @@
       "dependencies": {
         "@types/node": "*",
         "form-data": "^4.0.4"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
       }
     },
     "node_modules/ansi-styles": {
@@ -77,6 +337,16 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "license": "MIT"
     },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
     "node_modules/basic-auth": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
@@ -88,6 +358,19 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/call-bind-apply-helpers": {
@@ -179,6 +462,21 @@
         "node": ">= 0.4.0"
       }
     },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -196,6 +494,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
@@ -277,12 +582,265 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.3.0.tgz",
+      "integrity": "sha512-XbEXaRva5cF0ZQB8w6MluHA0kZZfV2DuCMJ3ozyEOHLwDpZX2Lmm/7Pp0xdJmI0GL1W05VH5VwIFHEm1Vcw2gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.2",
+        "@eslint/config-array": "^0.23.5",
+        "@eslint/config-helpers": "^0.5.5",
+        "@eslint/core": "^1.2.1",
+        "@eslint/plugin-kit": "^0.7.1",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "ajv": "^6.14.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^9.1.2",
+        "eslint-visitor-keys": "^5.0.1",
+        "espree": "^11.2.0",
+        "esquery": "^1.7.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "minimatch": "^10.2.4",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-config-prettier": {
+      "version": "10.1.8",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.8.tgz",
+      "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "eslint-config-prettier": "bin/cli.js"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-config-prettier"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.2.tgz",
+      "integrity": "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@types/esrecurse": "^4.3.1",
+        "@types/estree": "^1.0.8",
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/espree": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
+      "integrity": "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.16.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^5.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/eventemitter3": {
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
       "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/follow-redirects": {
       "version": "1.16.0",
@@ -365,6 +923,32 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/globals": {
+      "version": "17.6.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.6.0.tgz",
+      "integrity": "sha512-sepffkT8stwnIYbsMBpoCHJuJM5l98FUF2AnE07hfvE0m/qp3R586hw4jF4uadbhvg1ooIdzuu7CsfD2jzCaNA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/gopd": {
@@ -507,6 +1091,117 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -550,6 +1245,22 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/minimist": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
@@ -564,6 +1275,13 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true,
       "license": "MIT"
     },
@@ -610,6 +1328,76 @@
         "opener": "bin/opener-bin.js"
       }
     },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/portfinder": {
       "version": "1.0.38",
       "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.38.tgz",
@@ -622,6 +1410,42 @@
       },
       "engines": {
         "node": ">= 10.12"
+      }
+    },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
+      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/qs": {
@@ -667,6 +1491,29 @@
       "integrity": "sha512-AckIIV90rPDcBcglUwXPF3kg0P0qmPsPXAj6BBEENQE1p5yA1xfmDJzfi1Tappj37Pv2mVbKpL3Z1T+Nn7k1Qw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/side-channel": {
       "version": "1.1.0",
@@ -763,6 +1610,19 @@
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
       "license": "MIT"
     },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/undici-types": {
       "version": "7.19.2",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
@@ -779,6 +1639,16 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
       }
     },
     "node_modules/url-join": {
@@ -816,6 +1686,45 @@
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -5,9 +5,17 @@
   "main": "scripts/fetch-notion-data.js",
   "scripts": {
     "fetch-data": "node scripts/fetch-notion-data.js",
-    "dev": "http-server docs -c-1 -o"
+    "dev": "http-server docs -c-1 -o",
+    "lint": "eslint scripts/ docs/js/",
+    "lint:fix": "eslint scripts/ docs/js/ --fix",
+    "format": "prettier --write scripts/ docs/js/ eslint.config.js"
   },
-  "keywords": ["notion", "dashboard", "fitness", "training"],
+  "keywords": [
+    "notion",
+    "dashboard",
+    "fitness",
+    "training"
+  ],
   "author": "",
   "license": "MIT",
   "dependencies": {
@@ -15,6 +23,11 @@
     "dotenv": "^16.3.1"
   },
   "devDependencies": {
-    "http-server": "^14.1.1"
+    "@eslint/js": "^10.0.1",
+    "eslint": "^10.3.0",
+    "eslint-config-prettier": "^10.1.8",
+    "globals": "^17.6.0",
+    "http-server": "^14.1.1",
+    "prettier": "^3.8.3"
   }
 }

--- a/scripts/fetch-notion-data.js
+++ b/scripts/fetch-notion-data.js
@@ -13,7 +13,6 @@ const databaseId = process.env.NOTION_DATABASE_ID;
 const PASOS_OBJETIVO = 10000;
 const DISCIPLINAS_ENTRENAMIENTO = ['Natación', 'Fuerza', 'Bici', 'Carrera', 'Mixto'];
 const DISCIPLINAS_DESCANSO = ['Descanso'];
-const DISCIPLINAS_SIN_ENTRENAR = ['Sin entrenamiento'];
 
 // Días de obligatorio descanso
 const DIAS_DESCANSO = [4, 5]; // jueves (4) y viernes (5)


### PR DESCRIPTION
## Cambios

### Punto 5 — Refactorizar `charts.js`
- Las funciones `renderHeatmap`, `renderPieChart`, `renderTrendChart` y `renderCharts` ahora viven en `docs/js/charts.js`
- `main.js` queda enfocado en datos, estado y lógica de UI

### Punto 6 — Insight cards automáticos
Nueva sección **Insights** (antes de la racha reciente) con 4 tarjetas:
- 🔥 Racha consecutiva de cumplimiento
- 🏊 Días desde última sesión de cardio
- 💪 Días desde última sesión de fuerza
- 👟 Promedio de pasos últimos 7 días vs media general

Cada card es verde (positivo), naranja (warning) o gris (neutral) según el valor.

### Linting
- **ESLint 9** con flat config (`eslint.config.js`)
  - `scripts/`: entorno Node, `no-console: off`
  - `docs/js/`: entorno browser, `prefer-const`, `no-unused-vars`
- **Prettier** con `.prettierrc`
- Scripts nuevos: `npm run lint`, `npm run lint:fix`, `npm run format`
- `npm run lint` pasa con **0 errores**

### Fix
- SW cache bumpeado a `v3` para invalidar el caché anterior

https://claude.ai/code/session_01QUVxVrajjC7qwZ4pETVW4X