### PR TITLE
feat: mejoras visuales en charts y resumen semanal

### DIFF
--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -701,6 +701,84 @@ canvas {
   font-family: 'Roboto Mono', monospace;
 }
 
+/* ── MONTHLY CARDS ── */
+.monthly-section {
+  margin-top: 20px;
+  padding-top: 18px;
+  border-top: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.monthly-section-title {
+  font-size: 0.72em;
+  font-weight: 700;
+  color: #4b5563;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  margin-bottom: 12px;
+}
+
+.monthly-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+  gap: 10px;
+}
+
+.month-card {
+  background: rgba(15, 23, 42, 0.4);
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  border-radius: 10px;
+  padding: 14px 16px;
+  transition: border-color 0.2s, transform 0.2s;
+}
+
+.month-card:hover {
+  border-color: rgba(167, 139, 250, 0.2);
+  transform: translateY(-2px);
+}
+
+.month-card-title {
+  font-family: 'Roboto Mono', monospace;
+  font-size: 0.78em;
+  font-weight: 700;
+  color: #9ca3af;
+  margin-bottom: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.month-stats {
+  display: flex;
+  justify-content: space-between;
+  gap: 6px;
+}
+
+.month-stat {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  flex: 1;
+}
+
+.month-stat-value {
+  font-family: 'Roboto Mono', monospace;
+  font-size: 1.4em;
+  font-weight: 800;
+  line-height: 1;
+}
+
+.month-stat-value.fill-fuerza { color: #a78bfa; }
+.month-stat-value.fill-cardio { color: #00d4ff; }
+.month-stat-value.fill-pasos  { color: #34d399; }
+
+.month-stat-label {
+  font-size: 0.65em;
+  color: #4b5563;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  text-align: center;
+}
+
 /* ── WEEK TABLE ── */
 .stats-detail {
   background: linear-gradient(135deg, rgba(30, 41, 59, 0.85), rgba(17, 24, 39, 0.8));

--- a/docs/js/charts.js
+++ b/docs/js/charts.js
@@ -208,7 +208,7 @@ function renderHeatmap() {
 
 function renderPieChart() {
   const ctx = document.getElementById('pieChart').getContext('2d');
-  const disciplinas = dashboardData.distribucionDisciplinas;
+  const disciplinas = dashboardData.distribucionDisciplinas.filter(d => d.nombre !== 'Descanso');
   const labels = disciplinas.map(d => `${d.nombre}: ${d.count} (${d.porcentaje}%)`);
   const data = disciplinas.map(d => d.count);
   const colores = ['#00d4ff', '#34d399', '#a78bfa', '#fbbf24', '#f87171', '#fb923c'];

--- a/docs/js/charts.js
+++ b/docs/js/charts.js
@@ -17,28 +17,26 @@ function renderTrendChart() {
     return date.toLocaleDateString('es-MX', { day: 'numeric', month: 'short' });
   });
   const data = todosLosDatos.map(d => d.pasos);
+  const colores = data.map(v => v >= 10000 ? 'rgba(0, 212, 255, 0.75)' : 'rgba(248, 113, 113, 0.7)');
 
   new Chart(ctx.getContext('2d'), {
-    type: 'line',
+    type: 'bar',
     data: {
       labels,
       datasets: [
         {
           label: 'Pasos diarios',
           data,
-          borderColor: '#00d4ff',
-          backgroundColor: 'rgba(0, 212, 255, 0.05)',
-          fill: true,
-          tension: 0.2,
-          pointRadius: todosLosDatos.length > 60 ? 1 : 3,
-          pointHoverRadius: 6,
-          borderWidth: 2,
-          pointBackgroundColor: '#00d4ff',
+          backgroundColor: colores,
+          borderColor: colores,
+          borderWidth: 0,
+          borderRadius: 2,
         },
         {
+          type: 'line',
           label: 'Meta (10k)',
           data: Array(labels.length).fill(10000),
-          borderColor: 'rgba(52, 211, 153, 0.4)',
+          borderColor: 'rgba(52, 211, 153, 0.5)',
           borderDash: [5, 5],
           fill: false,
           pointRadius: 0,

--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -147,42 +147,58 @@ function renderWeeklySummary() {
   const container = document.getElementById('weeklySummary');
   if (!container || !dashboardData.semanas) return;
 
-  const MESES = ['Ene','Feb','Mar','Abr','May','Jun','Jul','Ago','Sep','Oct','Nov','Dic'];
-  const DIAS_LABEL = ['L','M','X','J','V','S','D'];
-  const COLOR_ESTADO = {
-    verde:    '#34d399',
-    amarillo: '#fb923c',
-    rojo:     '#f87171',
-    gris:     '#1e293b',
-  };
+  const MESES_NOMBRE = ['Enero','Febrero','Marzo','Abril','Mayo','Junio','Julio','Agosto','Septiembre','Octubre','Noviembre','Diciembre'];
+  const MESES_CORTO  = ['Ene','Feb','Mar','Abr','May','Jun','Jul','Ago','Sep','Oct','Nov','Dic'];
+  const DIAS_LABEL   = ['L','M','X','J','V','S','D'];
+  const CARDIO_DISC  = ['Natación', 'Carrera', 'Bici'];
+  const COLOR_ESTADO = { verde: '#34d399', amarillo: '#fb923c', rojo: '#f87171', gris: '#1e293b' };
 
-  const hoyStr = new Date().toISOString().split('T')[0];
+  const hoy = new Date();
+  const hoyStr      = hoy.toISOString().split('T')[0];
+  const mesActual   = hoy.getFullYear() + '-' + String(hoy.getMonth() + 1).padStart(2, '0');
+  const inicioMes   = mesActual + '-01';
+  const finMes      = new Date(hoy.getFullYear(), hoy.getMonth() + 1, 0).toISOString().split('T')[0];
 
-  // Render newest week first
-  const semanas = [...dashboardData.semanas].reverse();
+  // Solo semanas del mes actual, de más nueva a más antigua
+  const semanasDelMes = [...dashboardData.semanas]
+    .filter(s => s.fin >= inicioMes && s.inicio <= finMes)
+    .reverse();
 
-  container.innerHTML = semanas.map(semana => {
+  // Agrupar días pasados por mes
+  const porMes = {};
+  (dashboardData.todosDatos || []).forEach(dia => {
+    const mes = dia.fecha.substring(0, 7);
+    if (mes >= mesActual) return;
+    if (!porMes[mes]) porMes[mes] = [];
+    porMes[mes].push(dia);
+  });
+
+  const mesesPasados = Object.keys(porMes).sort().reverse().map(mesKey => {
+    const dias = porMes[mesKey];
+    const [y, m] = mesKey.split('-');
+    return {
+      label:        `${MESES_NOMBRE[parseInt(m) - 1]} ${y}`,
+      diasFuerza:   dias.filter(d => d.disciplinas.includes('Fuerza')   || d.disciplinas.includes('Mixto')).length,
+      diasNatacion: dias.filter(d => d.disciplinas.some(disc => CARDIO_DISC.includes(disc)) || d.disciplinas.includes('Mixto')).length,
+      diasPasos:    dias.filter(d => d.cumplePasos).length,
+    };
+  });
+
+  // ── Tarjeta semanal ───────────────────────────────────────
+  function weekCard(semana) {
     const inicio = new Date(semana.inicio + 'T00:00:00');
     const fin    = new Date(semana.fin    + 'T00:00:00');
-    const fmtD   = d => `${d.getDate()} ${MESES[d.getMonth()]}`;
+    const fmtD   = d => `${d.getDate()} ${MESES_CORTO[d.getMonth()]}`;
     const label  = `${fmtD(inicio)} – ${fmtD(fin)} ${fin.getFullYear()}`;
 
-    const cumpleFuerza = semana.sesionesFuerza >= 5;
-    const cumpleCardio = semana.sesionesCardio >= 3;
-    const cumplePasos  = semana.diasPasos10k  >= 7;
-    const metasOk      = cumpleFuerza && cumpleCardio && cumplePasos;
-    const metasCero    = semana.sesionesFuerza === 0 && semana.sesionesCardio === 0 && semana.diasPasos10k === 0;
+    const metasOk   = semana.sesionesFuerza >= 5 && semana.sesionesCardio >= 3 && semana.diasPasos10k >= 7;
+    const metasCero = semana.sesionesFuerza === 0 && semana.sesionesCardio === 0 && semana.diasPasos10k === 0;
 
     let statusLabel, statusClass;
-    if (semana.esSemanaActual) {
-      statusLabel = 'En curso'; statusClass = 'status-encurso';
-    } else if (metasOk) {
-      statusLabel = 'Cumplida'; statusClass = 'status-cumplida';
-    } else if (metasCero) {
-      statusLabel = 'Fallida';  statusClass = 'status-fallida';
-    } else {
-      statusLabel = 'Parcial';  statusClass = 'status-parcial';
-    }
+    if (semana.esSemanaActual)  { statusLabel = 'En curso'; statusClass = 'status-encurso'; }
+    else if (metasOk)           { statusLabel = 'Cumplida'; statusClass = 'status-cumplida'; }
+    else if (metasCero)         { statusLabel = 'Fallida';  statusClass = 'status-fallida'; }
+    else                        { statusLabel = 'Parcial';  statusClass = 'status-parcial'; }
 
     function bar(value, goal, cls, title) {
       const pct = Math.min(100, Math.round((value / goal) * 100));
@@ -195,7 +211,6 @@ function renderWeeklySummary() {
         </div>`;
     }
 
-    // Day dots — compute position from date offset relative to week start
     const diasMap = {};
     semana.diasResumen.forEach(d => {
       const diff = Math.round((new Date(d.fecha + 'T00:00:00') - inicio) / 86400000);
@@ -218,7 +233,7 @@ function renderWeeklySummary() {
       }
 
       const tip = dia && dia.disciplinaPrincipal
-        ? `${slotStr} · ${dia.disciplinaPrincipal} · ${(dia.pasos||0).toLocaleString('es-MX')} pasos`
+        ? `${slotStr} · ${dia.disciplinaPrincipal} · ${(dia.pasos || 0).toLocaleString('es-MX')} pasos`
         : slotStr;
 
       return `<div class="day-dot"><div class="day-dot-color" style="background:${bg};${border}" title="${tip}"></div><span class="day-dot-label">${lbl}</span></div>`;
@@ -237,7 +252,39 @@ function renderWeeklySummary() {
         </div>
         <div class="week-dots">${dots}</div>
       </div>`;
-  }).join('');
+  }
+
+  // ── Tarjeta mensual ───────────────────────────────────────
+  function monthCard(mes) {
+    return `
+      <div class="month-card">
+        <div class="month-card-title">${mes.label}</div>
+        <div class="month-stats">
+          <div class="month-stat">
+            <span class="month-stat-value fill-fuerza">${mes.diasFuerza}</span>
+            <span class="month-stat-label">Fuerza</span>
+          </div>
+          <div class="month-stat">
+            <span class="month-stat-value fill-cardio">${mes.diasNatacion}</span>
+            <span class="month-stat-label">Natación</span>
+          </div>
+          <div class="month-stat">
+            <span class="month-stat-value fill-pasos">${mes.diasPasos}</span>
+            <span class="month-stat-label">Pasos 10k</span>
+          </div>
+        </div>
+      </div>`;
+  }
+
+  const weeklyHTML  = semanasDelMes.map(weekCard).join('');
+  const monthlyHTML = mesesPasados.length
+    ? `<div class="monthly-section">
+        <div class="monthly-section-title">Meses anteriores</div>
+        <div class="monthly-grid">${mesesPasados.map(monthCard).join('')}</div>
+       </div>`
+    : '';
+
+  container.innerHTML = weeklyHTML + monthlyHTML;
 }
 
 function computeInsights() {

--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -66,13 +66,26 @@ function renderDashboard() {
 
 function renderRachas() {
   const container = document.getElementById('rachaCards');
-  if (!container || !dashboardData.rachas) return;
+  if (!container || !dashboardData.todosDatos) return;
 
-  const ventanas = [
-    dashboardData.rachas.d7,
-    dashboardData.rachas.d15,
-    dashboardData.rachas.d30,
-  ];
+  const CARDIO = ['Natación', 'Carrera', 'Bici'];
+  const hoy = new Date().toISOString().split('T')[0];
+  const datos = dashboardData.todosDatos;
+
+  function calcVentana(n) {
+    const corte = new Date();
+    corte.setDate(corte.getDate() - (n - 1));
+    const corteStr = corte.toISOString().split('T')[0];
+    const ventana = datos.filter(d => d.fecha >= corteStr && d.fecha <= hoy);
+    return {
+      dias: n,
+      pasos:  ventana.filter(d => d.cumplePasos).length,
+      fuerza: ventana.filter(d => d.disciplinas.includes('Fuerza') || d.disciplinas.includes('Mixto')).length,
+      cardio: ventana.filter(d => d.disciplinas.some(disc => CARDIO.includes(disc)) || d.disciplinas.includes('Mixto')).length,
+    };
+  }
+
+  const ventanas = [calcVentana(7), calcVentana(15), calcVentana(30)];
 
   container.innerHTML = ventanas.map(v => {
     const pctPasos  = Math.round((v.pasos  / v.dias) * 100);

--- a/docs/sw.js
+++ b/docs/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'bitacora-v4';
+const CACHE_NAME = 'bitacora-v5';
 
 const STATIC_ASSETS = [
   '/bitacora-entrenamiento/',

--- a/docs/sw.js
+++ b/docs/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'bitacora-v3';
+const CACHE_NAME = 'bitacora-v4';
 
 const STATIC_ASSETS = [
   '/bitacora-entrenamiento/',

--- a/docs/sw.js
+++ b/docs/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'bitacora-v5';
+const CACHE_NAME = 'bitacora-v6';
 
 const STATIC_ASSETS = [
   '/bitacora-entrenamiento/',


### PR DESCRIPTION
## Cambios

- **Tendencia de pasos**: cambiado de línea a barras coloreadas — azul si llega a 10k, rojo si no llega
- **Resumen semanal**: solo muestra semanas del mes actual; meses anteriores se condensan en una tarjeta compacta con días de fuerza, natación y pasos 10k
- **Distribución por disciplina**: se excluye "Descanso" del chart
- **Racha reciente**: calculada desde `todosDatos` en el frontend (no depende del campo `rachas` del data.json)
- SW cache bumpeado a `v6`

https://claude.ai/code/session_01QUVxVrajjC7qwZ4pETVW4X

---
_Generated by [Claude Code](https://claude.ai/code/session_01QUVxVrajjC7qwZ4pETVW4X)_