### PR TITLE
feat: resolución issue #5 — polish de charts y nuevos KPIs

### DIFF
--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -113,7 +113,7 @@ body {
 }
 
 .stat-number.verde {
-  color: #34d399;
+  color: #26a641;
 }
 
 .stat-number.amarillo {
@@ -511,7 +511,7 @@ canvas {
   flex-shrink: 0;
 }
 
-.legend-dot.verde  { background: #34d399; }
+.legend-dot.verde  { background: #26a641; }
 .legend-dot.naranja { background: #fb923c; }
 .legend-dot.rojo   { background: #f87171; }
 .legend-dot.gris   { background: #374151; border: 1px solid rgba(255,255,255,0.15); }
@@ -734,6 +734,24 @@ canvas {
 .month-card:hover {
   border-color: rgba(167, 139, 250, 0.2);
   transform: translateY(-2px);
+}
+
+.month-card--record {
+  border-color: rgba(38, 166, 65, 0.4);
+  box-shadow: 0 0 16px rgba(38, 166, 65, 0.1);
+}
+
+.month-record-badge {
+  font-size: 0.6em;
+  font-weight: 700;
+  padding: 1px 7px;
+  border-radius: 20px;
+  background: rgba(38, 166, 65, 0.15);
+  color: #26a641;
+  border: 1px solid rgba(38, 166, 65, 0.3);
+  letter-spacing: 0.05em;
+  vertical-align: middle;
+  margin-left: 6px;
 }
 
 .month-card-title {

--- a/docs/index.html
+++ b/docs/index.html
@@ -40,6 +40,10 @@
         <div class="stat-number" id="promedioPasos">0</div>
         <div class="stat-label">Promedio de pasos</div>
       </div>
+      <div class="stat-card">
+        <div class="stat-number verde" id="recordPasos">0</div>
+        <div class="stat-label">Récord de pasos</div>
+      </div>
     </section>
 
     <section class="insights-section">

--- a/docs/js/charts.js
+++ b/docs/js/charts.js
@@ -52,11 +52,17 @@ function renderTrendChart() {
         legend: {
           display: true,
           position: 'top',
-          labels: { color: '#9ca3af', boxWidth: 20, font: { size: 11 } },
+          labels: {
+            color: '#9ca3af',
+            boxWidth: 20,
+            font: { size: 11 },
+            filter: item => item.datasetIndex === 0,
+          },
         },
         tooltip: {
           backgroundColor: 'rgba(15, 23, 42, 0.9)',
           padding: 12,
+          filter: item => item.datasetIndex === 0,
           callbacks: {
             label(context) {
               const val = context.parsed.y;
@@ -90,7 +96,7 @@ function renderHeatmap() {
   container.innerHTML = '';
 
   const colorMap = {
-    verde: '#34d399',
+    verde: '#26a641',
     amarillo: '#fb923c',
     rojo: '#f87171',
     gris: '#1e293b',

--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -42,11 +42,13 @@ function renderDashboard() {
   document.getElementById('updated').textContent = new Date(dashboardData.actualizado).toLocaleString('es-ES');
 
   // Estadísticas principales
+  const recordPasos = Math.max(...dashboardData.todosDatos.map(d => d.pasos));
   document.getElementById('totalDias').textContent = stats.totalDias;
   document.getElementById('diasCumplimiento').textContent = `${stats.diasCumplimiento}/${stats.totalDias}`;
   document.getElementById('diasEjercicio').textContent = stats.diasEjercicio;
   document.getElementById('diasPasos').textContent = stats.diasPasos;
   document.getElementById('promedioPasos').textContent = stats.promedioPasos.toLocaleString('es-MX');
+  document.getElementById('recordPasos').textContent = recordPasos.toLocaleString('es-MX');
 
   // Insights automáticos
   renderInsights();
@@ -151,7 +153,7 @@ function renderWeeklySummary() {
   const MESES_CORTO  = ['Ene','Feb','Mar','Abr','May','Jun','Jul','Ago','Sep','Oct','Nov','Dic'];
   const DIAS_LABEL   = ['L','M','X','J','V','S','D'];
   const CARDIO_DISC  = ['Natación', 'Carrera', 'Bici'];
-  const COLOR_ESTADO = { verde: '#34d399', amarillo: '#fb923c', rojo: '#f87171', gris: '#1e293b' };
+  const COLOR_ESTADO = { verde: '#26a641', amarillo: '#fb923c', rojo: '#f87171', gris: '#1e293b' };
 
   const hoy = new Date();
   const hoyStr      = hoy.toISOString().split('T')[0];
@@ -254,11 +256,20 @@ function renderWeeklySummary() {
       </div>`;
   }
 
-  // ── Tarjeta mensual ───────────────────────────────────────
+  // Mes con mayor actividad total
+  const maxScore = mesesPasados.length
+    ? Math.max(...mesesPasados.map(m => m.diasFuerza + m.diasNatacion + m.diasPasos))
+    : 0;
+
   function monthCard(mes) {
+    const score = mes.diasFuerza + mes.diasNatacion + mes.diasPasos;
+    const esRecord = score === maxScore && maxScore > 0;
     return `
-      <div class="month-card">
-        <div class="month-card-title">${mes.label}</div>
+      <div class="month-card${esRecord ? ' month-card--record' : ''}">
+        <div class="month-card-title">
+          ${mes.label}
+          ${esRecord ? '<span class="month-record-badge">Récord</span>' : ''}
+        </div>
         <div class="month-stats">
           <div class="month-stat">
             <span class="month-stat-value fill-fuerza">${mes.diasFuerza}</span>

--- a/docs/sw.js
+++ b/docs/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'bitacora-v6';
+const CACHE_NAME = 'bitacora-v7';
 
 const STATIC_ASSETS = [
   '/bitacora-entrenamiento/',


### PR DESCRIPTION
Cierra #5

## Cambios

- **Trend chart**: se oculta "Meta (10k)" de la leyenda y del tooltip — ya es obvio por la línea punteada
- **Récord de pasos**: nueva tarjeta en verde en el stats grid superior
- **Mes récord**: el mes con más actividad acumulada (fuerza + natación + pasos) se marca con badge "Récord" y borde verde
- **Verde más suave**: cambiado de `#34d399` (teal brillante) a `#26a641` (verde GitHub) en heatmap, dots semanales y leyenda

https://claude.ai/code/session_01QUVxVrajjC7qwZ4pETVW4X

---
_Generated by [Claude Code](https://claude.ai/code/session_01QUVxVrajjC7qwZ4pETVW4X)_