### PR TITLE
feat: barra récord en pasos y heatmap simplificado a 3 estados

### DIFF
--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -511,10 +511,9 @@ canvas {
   flex-shrink: 0;
 }
 
-.legend-dot.verde  { background: #26a641; }
-.legend-dot.naranja { background: #fb923c; }
-.legend-dot.rojo   { background: #f87171; }
-.legend-dot.gris   { background: #374151; border: 1px solid rgba(255,255,255,0.15); }
+.legend-dot.verde      { background: #26a641; }
+.legend-dot.verde-bajo { background: #006d32; }
+.legend-dot.gris       { background: #374151; border: 1px solid rgba(255,255,255,0.15); }
 
 /* ── WEEKLY SUMMARY ── */
 .weekly-summary-section {

--- a/docs/index.html
+++ b/docs/index.html
@@ -63,19 +63,15 @@
         <div class="chart-legend">
           <div class="legend-item">
             <span class="legend-dot verde"></span>
-            <span>Ejercicio + pasos 10k <em>(Jue/Vie: solo pasos 10k)</em></span>
+            <span>Entrenamiento y pasos 10k <em>(Jue/Vie: solo pasos 10k)</em></span>
           </div>
           <div class="legend-item">
-            <span class="legend-dot naranja"></span>
-            <span>Ejercicio o pasos 10k</span>
-          </div>
-          <div class="legend-item">
-            <span class="legend-dot rojo"></span>
-            <span>Ni ejercicio ni pasos</span>
+            <span class="legend-dot verde-bajo"></span>
+            <span>Solo entrenamiento o solo pasos</span>
           </div>
           <div class="legend-item">
             <span class="legend-dot gris"></span>
-            <span>Sin registro</span>
+            <span>Sin metas / Sin registro</span>
           </div>
         </div>
       </div>

--- a/docs/js/charts.js
+++ b/docs/js/charts.js
@@ -17,7 +17,11 @@ function renderTrendChart() {
     return date.toLocaleDateString('es-MX', { day: 'numeric', month: 'short' });
   });
   const data = todosLosDatos.map(d => d.pasos);
-  const colores = data.map(v => v >= 10000 ? 'rgba(0, 212, 255, 0.75)' : 'rgba(248, 113, 113, 0.7)');
+  const maxPasos = Math.max(...data);
+  const colores = data.map(v => {
+    if (v === maxPasos && v > 0) return '#26a641';
+    return v >= 10000 ? 'rgba(0, 212, 255, 0.75)' : 'rgba(248, 113, 113, 0.7)';
+  });
 
   new Chart(ctx.getContext('2d'), {
     type: 'bar',
@@ -96,11 +100,11 @@ function renderHeatmap() {
   container.innerHTML = '';
 
   const colorMap = {
-    verde: '#26a641',
-    amarillo: '#fb923c',
-    rojo: '#f87171',
-    gris: '#1e293b',
-    futuro: 'transparent',
+    verde:    '#26a641',
+    amarillo: '#006d32',
+    rojo:     '#1e293b',
+    gris:     '#1e293b',
+    futuro:   'transparent',
   };
   const estadoLabel = { verde: 'Verde', amarillo: 'Naranja', rojo: 'Rojo', gris: 'Sin datos', futuro: 'Próximamente' };
   const MONTHS = ['Ene', 'Feb', 'Mar', 'Abr', 'May', 'Jun', 'Jul', 'Ago', 'Sep', 'Oct', 'Nov', 'Dic'];
@@ -183,7 +187,7 @@ function renderHeatmap() {
 
       const color = colorMap[dia.estado];
       cell.style.background = color;
-      if (dia.estado !== 'gris' && dia.estado !== 'futuro') {
+      if (dia.estado === 'verde' || dia.estado === 'amarillo') {
         cell.style.boxShadow = `0 0 5px ${color}55`;
       }
 

--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -153,7 +153,7 @@ function renderWeeklySummary() {
   const MESES_CORTO  = ['Ene','Feb','Mar','Abr','May','Jun','Jul','Ago','Sep','Oct','Nov','Dic'];
   const DIAS_LABEL   = ['L','M','X','J','V','S','D'];
   const CARDIO_DISC  = ['Natación', 'Carrera', 'Bici'];
-  const COLOR_ESTADO = { verde: '#26a641', amarillo: '#fb923c', rojo: '#f87171', gris: '#1e293b' };
+  const COLOR_ESTADO = { verde: '#26a641', amarillo: '#006d32', rojo: '#1e293b', gris: '#1e293b' };
 
   const hoy = new Date();
   const hoyStr      = hoy.toISOString().split('T')[0];

--- a/docs/sw.js
+++ b/docs/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'bitacora-v7';
+const CACHE_NAME = 'bitacora-v8';
 
 const STATIC_ASSETS = [
   '/bitacora-entrenamiento/',


### PR DESCRIPTION
## Cambios

### Barra récord en gráfica de pasos
La barra con el valor máximo de pasos se pinta en verde `#26a641` para destacar el día récord visualmente, separado del azul (≥10k) y rojo (<10k).

### Heatmap simplificado a 3 estados
| Estado | Color | Condición |
|--------|-------|-----------|
| Verde `#26a641` | 🟢 | Entrenamiento + pasos 10k |
| Verde oscuro `#006d32` | 🟩 | Solo entrenamiento o solo pasos |
| Sin color `#1e293b` | ⬛ | Sin metas cumplidas o sin registro |

Los días rojos (sin ejercicio ni pasos) ahora se muestran igual que los días sin registro — más limpio visualmente. La leyenda se actualizó a 3 ítems.

https://claude.ai/code/session_01QUVxVrajjC7qwZ4pETVW4X

---
_Generated by [Claude Code](https://claude.ai/code/session_01QUVxVrajjC7qwZ4pETVW4X)_