### PR TITLE
feat: reorder charts layout and move day-of-week analysis to new section

### DIFF
--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -323,8 +323,8 @@ body {
 
 /* ── CHARTS ── */
 .charts-section {
-  display: flex;
-  flex-direction: column;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
   gap: 20px;
   margin-bottom: 24px;
 }
@@ -340,10 +340,6 @@ body {
   transition: border-color 0.25s ease;
 }
 
-.chart-container:last-child {
-  max-width: none;
-  align-self: auto;
-}
 
 .chart-container.full-width {
   grid-column: 1 / -1;
@@ -875,6 +871,10 @@ canvas {
   }
 
   .racha-cards {
+    grid-template-columns: 1fr;
+  }
+
+  .charts-section {
     grid-template-columns: 1fr;
   }
 

--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -10,13 +10,90 @@ body {
   font-family: 'Roboto', sans-serif;
   background: radial-gradient(circle at 20% 20%, #1f2937 0, #0e1729 35%, #0b1321 65%, #0a0f1a 100%);
   min-height: 100vh;
-  padding: 24px 20px;
+  padding: 0;
   color: #e2e8f0;
 }
 
+/* ── PAGE LAYOUT ── */
+.page-layout {
+  display: flex;
+  align-items: flex-start;
+  min-height: 100vh;
+}
+
+/* ── SIDEBAR ── */
+.sidebar {
+  width: 72px;
+  position: sticky;
+  top: 0;
+  height: 100vh;
+  overflow-y: auto;
+  flex-shrink: 0;
+  background: linear-gradient(180deg, rgba(12, 18, 32, 0.98), rgba(8, 12, 22, 0.99));
+  border-right: 1px solid rgba(255, 255, 255, 0.07);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 20px 0;
+  gap: 2px;
+  z-index: 50;
+}
+
+.sidebar-logo {
+  font-size: 1.3em;
+  margin-bottom: 22px;
+  opacity: 0.6;
+}
+
+.sidebar-nav {
+  list-style: none;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+}
+
+.sidebar-link {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  padding: 11px 4px;
+  width: 100%;
+  text-decoration: none;
+  color: #4b5563;
+  transition: color 0.2s, background 0.2s, border-color 0.2s;
+  border-left: 2px solid transparent;
+}
+
+.sidebar-link:hover {
+  color: #cbd5e1;
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.sidebar-link.active {
+  color: #00d4ff;
+  border-left-color: #00d4ff;
+  background: rgba(0, 212, 255, 0.06);
+}
+
+.sl-icon {
+  font-size: 1.15em;
+  line-height: 1;
+}
+
+.sl-label {
+  font-size: 0.56em;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  font-family: 'Roboto Mono', monospace;
+}
+
 .container {
+  flex: 1;
+  min-width: 0;
   max-width: 1200px;
-  margin: 0 auto;
+  padding: 24px 20px;
 }
 
 /* ── HEADER ── */
@@ -95,6 +172,30 @@ body {
   box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);
   text-align: center;
   transition: transform 0.25s ease, box-shadow 0.25s ease, border-color 0.25s ease;
+  position: relative;
+  overflow: hidden;
+}
+
+.stat-card::before {
+  content: '';
+  position: absolute;
+  top: 0; left: 0; right: 0;
+  height: 2px;
+  background: var(--card-accent, #00d4ff);
+  opacity: 0.85;
+}
+
+.stat-card--cyan   { --card-accent: #00d4ff; }
+.stat-card--green  { --card-accent: #26a641; }
+.stat-card--purple { --card-accent: #a78bfa; }
+.stat-card--teal   { --card-accent: #34d399; }
+.stat-card--gold   { --card-accent: #fbbf24; }
+
+.stat-card-icon {
+  display: block;
+  font-size: 1.5em;
+  margin-bottom: 10px;
+  line-height: 1;
 }
 
 .stat-card:hover {
@@ -366,6 +467,35 @@ canvas {
 
 #trendChart {
   min-height: 300px;
+}
+
+/* ── PIE + SIDE CHART ── */
+.pie-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 28px;
+  align-items: center;
+}
+
+.pie-side {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.side-chart-title {
+  font-size: 0.82em;
+  font-weight: 700;
+  color: #9ca3af;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  border-left: 3px solid #a78bfa;
+  padding-left: 10px;
+  margin: 0;
+}
+
+#dayChart {
+  min-height: 220px;
 }
 
 /* ── HEATMAP ── */
@@ -862,6 +992,10 @@ canvas {
 
 /* ── RESPONSIVE ── */
 @media (max-width: 768px) {
+  .sidebar {
+    display: none;
+  }
+
   .header h1 {
     font-size: 1.7em;
   }
@@ -875,6 +1009,10 @@ canvas {
   }
 
   .charts-section {
+    grid-template-columns: 1fr;
+  }
+
+  .pie-row {
     grid-template-columns: 1fr;
   }
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -11,112 +11,163 @@
   <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.js"></script>
 </head>
 <body>
-  <div class="container">
-    <header class="header">
-      <h1>📊 Bitácora de Entrenamiento</h1>
-      <p class="subtitle">Dashboard de seguimiento de metas de ejercicio y pasos</p>
-      <div class="period-legend">Periodo: 29 de diciembre 2025 al 25 de abril 2026</div>
-      <div class="last-updated">Última actualización: <span id="updated"></span></div>
-    </header>
+  <div class="page-layout">
 
-    <section class="stats-grid">
-      <div class="stat-card">
-        <div class="stat-number" id="totalDias">0</div>
-        <div class="stat-label">Días registrados</div>
-      </div>
-      <div class="stat-card">
-        <div class="stat-number verde" id="diasCumplimiento">0</div>
-        <div class="stat-label">Cumplimiento total</div>
-      </div>
-      <div class="stat-card">
-        <div class="stat-number" id="diasEjercicio">0</div>
-        <div class="stat-label">Días con ejercicio</div>
-      </div>
-      <div class="stat-card">
-        <div class="stat-number" id="diasPasos">0</div>
-        <div class="stat-label">Días con 10k+ pasos</div>
-      </div>
-      <div class="stat-card">
-        <div class="stat-number" id="promedioPasos">0</div>
-        <div class="stat-label">Promedio de pasos</div>
-      </div>
-      <div class="stat-card">
-        <div class="stat-number verde" id="recordPasos">0</div>
-        <div class="stat-label">Récord de pasos</div>
-      </div>
-    </section>
+    <nav class="sidebar" id="sidebar">
+      <div class="sidebar-logo">📊</div>
+      <ul class="sidebar-nav">
+        <li>
+          <a href="#kpis" class="sidebar-link active">
+            <span class="sl-icon">📊</span>
+            <span class="sl-label">KPIs</span>
+          </a>
+        </li>
+        <li>
+          <a href="#insights" class="sidebar-link">
+            <span class="sl-icon">💡</span>
+            <span class="sl-label">Insights</span>
+          </a>
+        </li>
+        <li>
+          <a href="#racha" class="sidebar-link">
+            <span class="sl-icon">🔥</span>
+            <span class="sl-label">Racha</span>
+          </a>
+        </li>
+        <li>
+          <a href="#graficas" class="sidebar-link">
+            <span class="sl-icon">📈</span>
+            <span class="sl-label">Gráficas</span>
+          </a>
+        </li>
+        <li>
+          <a href="#semanas" class="sidebar-link">
+            <span class="sl-icon">📅</span>
+            <span class="sl-label">Semanas</span>
+          </a>
+        </li>
+      </ul>
+    </nav>
 
-    <section class="insights-section">
-      <h2>Insights</h2>
-      <div class="insights-grid" id="insightsGrid"></div>
-    </section>
+    <div class="container">
+      <header class="header">
+        <h1>📊 Bitácora de Entrenamiento</h1>
+        <p class="subtitle">Dashboard de seguimiento de metas de ejercicio y pasos</p>
+        <div class="period-legend">Periodo: 29 de diciembre 2025 al 25 de abril 2026</div>
+        <div class="last-updated">Última actualización: <span id="updated"></span></div>
+      </header>
 
-    <section class="racha-section">
-      <h2>Racha reciente</h2>
-      <div class="racha-cards" id="rachaCards"></div>
-    </section>
+      <section id="kpis" class="stats-grid">
+        <div class="stat-card stat-card--cyan">
+          <span class="stat-card-icon">📅</span>
+          <div class="stat-number" id="totalDias">0</div>
+          <div class="stat-label">Días registrados</div>
+        </div>
+        <div class="stat-card stat-card--green">
+          <span class="stat-card-icon">✅</span>
+          <div class="stat-number verde" id="diasCumplimiento">0</div>
+          <div class="stat-label">Cumplimiento total</div>
+        </div>
+        <div class="stat-card stat-card--purple">
+          <span class="stat-card-icon">🏋️</span>
+          <div class="stat-number" id="diasEjercicio">0</div>
+          <div class="stat-label">Días con ejercicio</div>
+        </div>
+        <div class="stat-card stat-card--teal">
+          <span class="stat-card-icon">👟</span>
+          <div class="stat-number" id="diasPasos">0</div>
+          <div class="stat-label">Días con 10k+ pasos</div>
+        </div>
+        <div class="stat-card stat-card--cyan">
+          <span class="stat-card-icon">📊</span>
+          <div class="stat-number" id="promedioPasos">0</div>
+          <div class="stat-label">Promedio de pasos</div>
+        </div>
+        <div class="stat-card stat-card--gold">
+          <span class="stat-card-icon">🏆</span>
+          <div class="stat-number verde" id="recordPasos">0</div>
+          <div class="stat-label">Récord de pasos</div>
+        </div>
+      </section>
 
-    <section class="charts-section">
-      <div class="chart-container">
-        <h2>Distribución por disciplina</h2>
-        <canvas id="pieChart"></canvas>
-      </div>
+      <section id="insights" class="insights-section">
+        <h2>Insights</h2>
+        <div class="insights-grid" id="insightsGrid"></div>
+      </section>
 
-      <div class="chart-container">
-        <h2>Historial de entrenamiento</h2>
-        <div id="heatmap"></div>
-        <div class="chart-legend">
-          <div class="legend-item">
-            <span class="legend-dot verde"></span>
-            <span>Entrenamiento y pasos 10k <em>(Jue/Vie: solo pasos 10k)</em></span>
-          </div>
-          <div class="legend-item">
-            <span class="legend-dot verde-bajo"></span>
-            <span>Solo entrenamiento o solo pasos</span>
-          </div>
-          <div class="legend-item">
-            <span class="legend-dot gris"></span>
-            <span>Sin metas / Sin registro</span>
+      <section id="racha" class="racha-section">
+        <h2>Racha reciente</h2>
+        <div class="racha-cards" id="rachaCards"></div>
+      </section>
+
+      <section id="graficas" class="charts-section">
+        <div class="chart-container full-width">
+          <h2>Distribución por disciplina</h2>
+          <div class="pie-row">
+            <canvas id="pieChart"></canvas>
+            <div class="pie-side">
+              <h3 class="side-chart-title">Actividad por día de semana</h3>
+              <canvas id="dayChart"></canvas>
+            </div>
           </div>
         </div>
-      </div>
 
-      <div class="chart-container">
-        <h2>Tendencia de pasos (Historial completo)</h2>
-        <canvas id="trendChart"></canvas>
-      </div>
-
-      <div class="chart-container full-width">
-        <h2>Análisis por día de la semana</h2>
-        <table class="week-table">
-          <thead>
-            <tr>
-              <th>Día</th>
-              <th>Total registros</th>
-              <th>Con ejercicio</th>
-              <th>Con 10k+ pasos</th>
-            </tr>
-          </thead>
-          <tbody id="weekTable"></tbody>
-        </table>
-      </div>
-    </section>
-
-    <section class="weekly-summary-section">
-      <div class="weekly-header">
-        <h2>Resumen Semanal</h2>
-        <div class="weekly-goals-legend">
-          <span class="wgl-item wgl-fuerza">5 sesiones fuerza</span>
-          <span class="wgl-item wgl-cardio">3 sesiones cardio</span>
-          <span class="wgl-item wgl-pasos">10k pasos/día</span>
+        <div class="chart-container">
+          <h2>Historial de entrenamiento</h2>
+          <div id="heatmap"></div>
+          <div class="chart-legend">
+            <div class="legend-item">
+              <span class="legend-dot verde"></span>
+              <span>Entrenamiento y pasos 10k <em>(Jue/Vie: solo pasos 10k)</em></span>
+            </div>
+            <div class="legend-item">
+              <span class="legend-dot verde-bajo"></span>
+              <span>Solo entrenamiento o solo pasos</span>
+            </div>
+            <div class="legend-item">
+              <span class="legend-dot gris"></span>
+              <span>Sin metas / Sin registro</span>
+            </div>
+          </div>
         </div>
-      </div>
-      <div id="weeklySummary" class="weekly-grid"></div>
-    </section>
 
-<footer class="footer">
-      <p>Dashboard conectado a Notion • Actualizado automáticamente cada noche</p>
-    </footer>
+        <div class="chart-container">
+          <h2>Tendencia de pasos (Historial completo)</h2>
+          <canvas id="trendChart"></canvas>
+        </div>
+
+        <div class="chart-container full-width">
+          <h2>Análisis por día de la semana</h2>
+          <table class="week-table">
+            <thead>
+              <tr>
+                <th>Día</th>
+                <th>Total registros</th>
+                <th>Con ejercicio</th>
+                <th>Con 10k+ pasos</th>
+              </tr>
+            </thead>
+            <tbody id="weekTable"></tbody>
+          </table>
+        </div>
+      </section>
+
+      <section id="semanas" class="weekly-summary-section">
+        <div class="weekly-header">
+          <h2>Resumen Semanal</h2>
+          <div class="weekly-goals-legend">
+            <span class="wgl-item wgl-fuerza">5 sesiones fuerza</span>
+            <span class="wgl-item wgl-cardio">3 sesiones cardio</span>
+            <span class="wgl-item wgl-pasos">10k pasos/día</span>
+          </div>
+        </div>
+        <div id="weeklySummary" class="weekly-grid"></div>
+      </section>
+
+      <footer class="footer">
+        <p>Dashboard conectado a Notion • Actualizado automáticamente cada noche</p>
+      </footer>
+    </div>
   </div>
 
   <script src="js/main.js"></script>

--- a/docs/index.html
+++ b/docs/index.html
@@ -58,6 +58,11 @@
 
     <section class="charts-section">
       <div class="chart-container">
+        <h2>Distribución por disciplina</h2>
+        <canvas id="pieChart"></canvas>
+      </div>
+
+      <div class="chart-container">
         <h2>Historial de entrenamiento</h2>
         <div id="heatmap"></div>
         <div class="chart-legend">
@@ -77,13 +82,23 @@
       </div>
 
       <div class="chart-container">
-        <h2>Distribución por disciplina</h2>
-        <canvas id="pieChart"></canvas>
+        <h2>Tendencia de pasos (Historial completo)</h2>
+        <canvas id="trendChart"></canvas>
       </div>
 
       <div class="chart-container full-width">
-        <h2>Tendencia de pasos (Historial completo)</h2>
-        <canvas id="trendChart"></canvas>
+        <h2>Análisis por día de la semana</h2>
+        <table class="week-table">
+          <thead>
+            <tr>
+              <th>Día</th>
+              <th>Total registros</th>
+              <th>Con ejercicio</th>
+              <th>Con 10k+ pasos</th>
+            </tr>
+          </thead>
+          <tbody id="weekTable"></tbody>
+        </table>
       </div>
     </section>
 
@@ -99,22 +114,7 @@
       <div id="weeklySummary" class="weekly-grid"></div>
     </section>
 
-    <section class="stats-detail">
-      <h2>Análisis por día de la semana</h2>
-      <table class="week-table">
-        <thead>
-          <tr>
-            <th>Día</th>
-            <th>Total registros</th>
-            <th>Con ejercicio</th>
-            <th>Con 10k+ pasos</th>
-          </tr>
-        </thead>
-        <tbody id="weekTable"></tbody>
-      </table>
-    </section>
-
-    <footer class="footer">
+<footer class="footer">
       <p>Dashboard conectado a Notion • Actualizado automáticamente cada noche</p>
     </footer>
   </div>

--- a/docs/js/charts.js
+++ b/docs/js/charts.js
@@ -1,10 +1,11 @@
 /* global dashboardData */
-/* exported renderCharts, renderHeatmap, renderPieChart, renderTrendChart */
+/* exported renderCharts, renderHeatmap, renderPieChart, renderTrendChart, renderDayChart */
 
 function renderCharts() {
   renderHeatmap();
   renderPieChart();
   renderTrendChart();
+  renderDayChart();
 }
 
 function renderTrendChart() {
@@ -214,6 +215,75 @@ function renderHeatmap() {
   gridRow.appendChild(grid);
   container.appendChild(monthRow);
   container.appendChild(gridRow);
+}
+
+function renderDayChart() {
+  const ctx = document.getElementById('dayChart');
+  if (!ctx || !dashboardData.porDiaSemana) return;
+
+  const diasLabel = ['Lun', 'Mar', 'Mié', 'Jue', 'Vie', 'Sáb', 'Dom'];
+  const diasKey   = ['Lun', 'Mar', 'Mié', 'Jue', 'Vie', 'Sáb', 'Dom'];
+  const pds = dashboardData.porDiaSemana;
+
+  const ejercicioData = diasKey.map(k => (pds[k] || {}).ejercicio || 0);
+  const pasosData     = diasKey.map(k => (pds[k] || {}).pasos    || 0);
+
+  new Chart(ctx.getContext('2d'), {
+    type: 'bar',
+    data: {
+      labels: diasLabel,
+      datasets: [
+        {
+          label: 'Con ejercicio',
+          data: ejercicioData,
+          backgroundColor: 'rgba(167, 139, 250, 0.65)',
+          borderColor: '#a78bfa',
+          borderWidth: 1,
+          borderRadius: 4,
+        },
+        {
+          label: '10k+ pasos',
+          data: pasosData,
+          backgroundColor: 'rgba(52, 211, 153, 0.6)',
+          borderColor: '#34d399',
+          borderWidth: 1,
+          borderRadius: 4,
+        },
+      ],
+    },
+    options: {
+      responsive: true,
+      maintainAspectRatio: false,
+      plugins: {
+        legend: {
+          position: 'top',
+          labels: {
+            color: '#9ca3af',
+            boxWidth: 10,
+            font: { size: 11 },
+            usePointStyle: true,
+          },
+        },
+        tooltip: {
+          backgroundColor: 'rgba(15, 23, 42, 0.9)',
+          padding: 10,
+          titleColor: '#e2e8f0',
+          bodyColor: '#9ca3af',
+        },
+      },
+      scales: {
+        y: {
+          beginAtZero: true,
+          grid: { color: 'rgba(255, 255, 255, 0.05)' },
+          ticks: { color: '#64748b', font: { size: 10 } },
+        },
+        x: {
+          grid: { display: false },
+          ticks: { color: '#64748b', font: { size: 11 } },
+        },
+      },
+    },
+  });
 }
 
 function renderPieChart() {

--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -388,5 +388,33 @@ function renderInsights() {
     </div>`).join('');
 }
 
+function initSidebar() {
+  const sectionIds = ['kpis', 'insights', 'racha', 'graficas', 'semanas'];
+  const links = {};
+  sectionIds.forEach(id => {
+    const el = document.querySelector(`.sidebar-link[href="#${id}"]`);
+    if (el) links[id] = el;
+  });
+
+  if (!Object.keys(links).length) return;
+
+  const observer = new IntersectionObserver(entries => {
+    entries.forEach(entry => {
+      if (entry.isIntersecting) {
+        Object.values(links).forEach(l => l.classList.remove('active'));
+        if (links[entry.target.id]) links[entry.target.id].classList.add('active');
+      }
+    });
+  }, { rootMargin: '-15% 0px -75% 0px', threshold: 0 });
+
+  sectionIds.forEach(id => {
+    const el = document.getElementById(id);
+    if (el) observer.observe(el);
+  });
+}
+
 // Cargar datos al iniciar
-document.addEventListener('DOMContentLoaded', loadData);
+document.addEventListener('DOMContentLoaded', () => {
+  loadData();
+  initSidebar();
+});


### PR DESCRIPTION
- Distribución por disciplina moves to 1st place
- Historial de entrenamiento moves to 2nd (reduced to half-page width)
- Tendencia de pasos moves to 3rd (reduced to half-page width)
- Análisis por día de la semana moved into charts-section as full-width card
- charts-section changed from flex-column to 2-column CSS grid
- Responsive: grid collapses to 1 column on mobile

Closes tasks from issue #8

https://claude.ai/code/session_01Fwz2xdQdELWT3QUGh7gKZF