### PR TITLE
revert: charts al orden original + workflow a 1 PM México

### DIFF
--- a/.github/workflows/update-data.yml
+++ b/.github/workflows/update-data.yml
@@ -2,8 +2,8 @@ name: Update Training Data
 
 on:
   schedule:
-    # Ejecuta todos los días a las 00:00 UTC
-    - cron: '0 0 * * *'
+    # Ejecuta todos los días a la 1:00 PM hora México (UTC-6 = 19:00 UTC)
+    - cron: '0 19 * * *'
   workflow_dispatch:  # Permite ejecución manual
 
 env:

--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -424,8 +424,8 @@ body {
 
 /* ── CHARTS ── */
 .charts-section {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
+  display: flex;
+  flex-direction: column;
   gap: 20px;
   margin-bottom: 24px;
 }
@@ -469,34 +469,6 @@ canvas {
   min-height: 300px;
 }
 
-/* ── PIE + SIDE CHART ── */
-.pie-row {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 28px;
-  align-items: center;
-}
-
-.pie-side {
-  display: flex;
-  flex-direction: column;
-  gap: 14px;
-}
-
-.side-chart-title {
-  font-size: 0.82em;
-  font-weight: 700;
-  color: #9ca3af;
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
-  border-left: 3px solid #a78bfa;
-  padding-left: 10px;
-  margin: 0;
-}
-
-#dayChart {
-  min-height: 220px;
-}
 
 /* ── HEATMAP ── */
 #heatmap {
@@ -1005,14 +977,6 @@ canvas {
   }
 
   .racha-cards {
-    grid-template-columns: 1fr;
-  }
-
-  .charts-section {
-    grid-template-columns: 1fr;
-  }
-
-  .pie-row {
     grid-template-columns: 1fr;
   }
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -101,17 +101,6 @@
       </section>
 
       <section id="graficas" class="charts-section">
-        <div class="chart-container full-width">
-          <h2>Distribución por disciplina</h2>
-          <div class="pie-row">
-            <canvas id="pieChart"></canvas>
-            <div class="pie-side">
-              <h3 class="side-chart-title">Actividad por día de semana</h3>
-              <canvas id="dayChart"></canvas>
-            </div>
-          </div>
-        </div>
-
         <div class="chart-container">
           <h2>Historial de entrenamiento</h2>
           <div id="heatmap"></div>
@@ -132,6 +121,11 @@
         </div>
 
         <div class="chart-container">
+          <h2>Distribución por disciplina</h2>
+          <canvas id="pieChart"></canvas>
+        </div>
+
+        <div class="chart-container full-width">
           <h2>Tendencia de pasos (Historial completo)</h2>
           <canvas id="trendChart"></canvas>
         </div>
@@ -161,7 +155,6 @@
             <span class="wgl-item wgl-pasos">10k pasos/día</span>
           </div>
         </div>
-        <div id="thisWeekPanel" class="this-week-panel"></div>
         <div id="weeklySummary" class="weekly-grid"></div>
       </section>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -155,6 +155,7 @@
             <span class="wgl-item wgl-pasos">10k pasos/día</span>
           </div>
         </div>
+        <div id="thisWeekPanel" class="this-week-panel"></div>
         <div id="weeklySummary" class="weekly-grid"></div>
       </section>
 

--- a/docs/js/charts.js
+++ b/docs/js/charts.js
@@ -1,11 +1,10 @@
 /* global dashboardData */
-/* exported renderCharts, renderHeatmap, renderPieChart, renderTrendChart, renderDayChart */
+/* exported renderCharts, renderHeatmap, renderPieChart, renderTrendChart */
 
 function renderCharts() {
   renderHeatmap();
   renderPieChart();
   renderTrendChart();
-  renderDayChart();
 }
 
 function renderTrendChart() {
@@ -215,75 +214,6 @@ function renderHeatmap() {
   gridRow.appendChild(grid);
   container.appendChild(monthRow);
   container.appendChild(gridRow);
-}
-
-function renderDayChart() {
-  const ctx = document.getElementById('dayChart');
-  if (!ctx || !dashboardData.porDiaSemana) return;
-
-  const diasLabel = ['Lun', 'Mar', 'Mié', 'Jue', 'Vie', 'Sáb', 'Dom'];
-  const diasKey   = ['Lun', 'Mar', 'Mié', 'Jue', 'Vie', 'Sáb', 'Dom'];
-  const pds = dashboardData.porDiaSemana;
-
-  const ejercicioData = diasKey.map(k => (pds[k] || {}).ejercicio || 0);
-  const pasosData     = diasKey.map(k => (pds[k] || {}).pasos    || 0);
-
-  new Chart(ctx.getContext('2d'), {
-    type: 'bar',
-    data: {
-      labels: diasLabel,
-      datasets: [
-        {
-          label: 'Con ejercicio',
-          data: ejercicioData,
-          backgroundColor: 'rgba(167, 139, 250, 0.65)',
-          borderColor: '#a78bfa',
-          borderWidth: 1,
-          borderRadius: 4,
-        },
-        {
-          label: '10k+ pasos',
-          data: pasosData,
-          backgroundColor: 'rgba(52, 211, 153, 0.6)',
-          borderColor: '#34d399',
-          borderWidth: 1,
-          borderRadius: 4,
-        },
-      ],
-    },
-    options: {
-      responsive: true,
-      maintainAspectRatio: false,
-      plugins: {
-        legend: {
-          position: 'top',
-          labels: {
-            color: '#9ca3af',
-            boxWidth: 10,
-            font: { size: 11 },
-            usePointStyle: true,
-          },
-        },
-        tooltip: {
-          backgroundColor: 'rgba(15, 23, 42, 0.9)',
-          padding: 10,
-          titleColor: '#e2e8f0',
-          bodyColor: '#9ca3af',
-        },
-      },
-      scales: {
-        y: {
-          beginAtZero: true,
-          grid: { color: 'rgba(255, 255, 255, 0.05)' },
-          ticks: { color: '#64748b', font: { size: 10 } },
-        },
-        x: {
-          grid: { display: false },
-          ticks: { color: '#64748b', font: { size: 11 } },
-        },
-      },
-    },
-  });
 }
 
 function renderPieChart() {

--- a/docs/sw.js
+++ b/docs/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'bitacora-v10';
+const CACHE_NAME = 'bitacora-v11';
 
 const STATIC_ASSETS = [
   '/bitacora-entrenamiento/',

--- a/docs/sw.js
+++ b/docs/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'bitacora-v9';
+const CACHE_NAME = 'bitacora-v10';
 
 const STATIC_ASSETS = [
   '/bitacora-entrenamiento/',


### PR DESCRIPTION
## Cambios

### UI — Gráficas
- `charts-section` regresa a `flex-column` (ancho completo, sin grid de 2 columnas)
- Orden restaurado: **Historial de entrenamiento → Distribución por disciplina → Tendencia de pasos**
- Eliminado `dayChart` (gráfica de actividad por día) y el layout `pie-row`

### Workflow
- Schedule cambiado de `00:00 UTC` → `19:00 UTC` **(1:00 PM hora México, UTC-6)**

### Service Worker
- Bumpeado a `bitacora-v10` para forzar refresco de caché

## Sin conflictos
Rama creada limpia desde `master` — sin conflictos de merge.

## Test plan
- [ ] Verificar que las gráficas se muestran en el orden correcto y ancho completo
- [ ] Confirmar que el workflow corre a la 1 PM México

https://claude.ai/code/session_01Fwz2xdQdELWT3QUGh7gKZF

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fwz2xdQdELWT3QUGh7gKZF)_