### PR TITLE
fix: revert UI redesign, keep schedule + backup

### DIFF
--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -10,90 +10,13 @@ body {
   font-family: 'Roboto', sans-serif;
   background: radial-gradient(circle at 20% 20%, #1f2937 0, #0e1729 35%, #0b1321 65%, #0a0f1a 100%);
   min-height: 100vh;
-  padding: 0;
+  padding: 24px 20px;
   color: #e2e8f0;
 }
 
-/* ── PAGE LAYOUT ── */
-.page-layout {
-  display: flex;
-  align-items: flex-start;
-  min-height: 100vh;
-}
-
-/* ── SIDEBAR ── */
-.sidebar {
-  width: 72px;
-  position: sticky;
-  top: 0;
-  height: 100vh;
-  overflow-y: auto;
-  flex-shrink: 0;
-  background: linear-gradient(180deg, rgba(12, 18, 32, 0.98), rgba(8, 12, 22, 0.99));
-  border-right: 1px solid rgba(255, 255, 255, 0.07);
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  padding: 20px 0;
-  gap: 2px;
-  z-index: 50;
-}
-
-.sidebar-logo {
-  font-size: 1.3em;
-  margin-bottom: 22px;
-  opacity: 0.6;
-}
-
-.sidebar-nav {
-  list-style: none;
-  width: 100%;
-  display: flex;
-  flex-direction: column;
-}
-
-.sidebar-link {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 4px;
-  padding: 11px 4px;
-  width: 100%;
-  text-decoration: none;
-  color: #4b5563;
-  transition: color 0.2s, background 0.2s, border-color 0.2s;
-  border-left: 2px solid transparent;
-}
-
-.sidebar-link:hover {
-  color: #cbd5e1;
-  background: rgba(255, 255, 255, 0.04);
-}
-
-.sidebar-link.active {
-  color: #00d4ff;
-  border-left-color: #00d4ff;
-  background: rgba(0, 212, 255, 0.06);
-}
-
-.sl-icon {
-  font-size: 1.15em;
-  line-height: 1;
-}
-
-.sl-label {
-  font-size: 0.56em;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
-  font-family: 'Roboto Mono', monospace;
-}
-
 .container {
-  flex: 1;
-  min-width: 0;
   max-width: 1200px;
-  padding: 24px 20px;
+  margin: 0 auto;
 }
 
 /* ── HEADER ── */
@@ -172,30 +95,6 @@ body {
   box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);
   text-align: center;
   transition: transform 0.25s ease, box-shadow 0.25s ease, border-color 0.25s ease;
-  position: relative;
-  overflow: hidden;
-}
-
-.stat-card::before {
-  content: '';
-  position: absolute;
-  top: 0; left: 0; right: 0;
-  height: 2px;
-  background: var(--card-accent, #00d4ff);
-  opacity: 0.85;
-}
-
-.stat-card--cyan   { --card-accent: #00d4ff; }
-.stat-card--green  { --card-accent: #26a641; }
-.stat-card--purple { --card-accent: #a78bfa; }
-.stat-card--teal   { --card-accent: #34d399; }
-.stat-card--gold   { --card-accent: #fbbf24; }
-
-.stat-card-icon {
-  display: block;
-  font-size: 1.5em;
-  margin-bottom: 10px;
-  line-height: 1;
 }
 
 .stat-card:hover {
@@ -441,6 +340,10 @@ body {
   transition: border-color 0.25s ease;
 }
 
+.chart-container:last-child {
+  max-width: none;
+  align-self: auto;
+}
 
 .chart-container.full-width {
   grid-column: 1 / -1;
@@ -468,7 +371,6 @@ canvas {
 #trendChart {
   min-height: 300px;
 }
-
 
 /* ── HEATMAP ── */
 #heatmap {
@@ -964,10 +866,6 @@ canvas {
 
 /* ── RESPONSIVE ── */
 @media (max-width: 768px) {
-  .sidebar {
-    display: none;
-  }
-
   .header h1 {
     font-size: 1.7em;
   }

--- a/docs/index.html
+++ b/docs/index.html
@@ -11,158 +11,113 @@
   <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.js"></script>
 </head>
 <body>
-  <div class="page-layout">
+  <div class="container">
+    <header class="header">
+      <h1>📊 Bitácora de Entrenamiento</h1>
+      <p class="subtitle">Dashboard de seguimiento de metas de ejercicio y pasos</p>
+      <div class="period-legend">Periodo: 29 de diciembre 2025 al 25 de abril 2026</div>
+      <div class="last-updated">Última actualización: <span id="updated"></span></div>
+    </header>
 
-    <nav class="sidebar" id="sidebar">
-      <div class="sidebar-logo">📊</div>
-      <ul class="sidebar-nav">
-        <li>
-          <a href="#kpis" class="sidebar-link active">
-            <span class="sl-icon">📊</span>
-            <span class="sl-label">KPIs</span>
-          </a>
-        </li>
-        <li>
-          <a href="#insights" class="sidebar-link">
-            <span class="sl-icon">💡</span>
-            <span class="sl-label">Insights</span>
-          </a>
-        </li>
-        <li>
-          <a href="#racha" class="sidebar-link">
-            <span class="sl-icon">🔥</span>
-            <span class="sl-label">Racha</span>
-          </a>
-        </li>
-        <li>
-          <a href="#graficas" class="sidebar-link">
-            <span class="sl-icon">📈</span>
-            <span class="sl-label">Gráficas</span>
-          </a>
-        </li>
-        <li>
-          <a href="#semanas" class="sidebar-link">
-            <span class="sl-icon">📅</span>
-            <span class="sl-label">Semanas</span>
-          </a>
-        </li>
-      </ul>
-    </nav>
+    <section class="stats-grid">
+      <div class="stat-card">
+        <div class="stat-number" id="totalDias">0</div>
+        <div class="stat-label">Días registrados</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-number verde" id="diasCumplimiento">0</div>
+        <div class="stat-label">Cumplimiento total</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-number" id="diasEjercicio">0</div>
+        <div class="stat-label">Días con ejercicio</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-number" id="diasPasos">0</div>
+        <div class="stat-label">Días con 10k+ pasos</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-number" id="promedioPasos">0</div>
+        <div class="stat-label">Promedio de pasos</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-number verde" id="recordPasos">0</div>
+        <div class="stat-label">Récord de pasos</div>
+      </div>
+    </section>
 
-    <div class="container">
-      <header class="header">
-        <h1>📊 Bitácora de Entrenamiento</h1>
-        <p class="subtitle">Dashboard de seguimiento de metas de ejercicio y pasos</p>
-        <div class="period-legend">Periodo: 29 de diciembre 2025 al 25 de abril 2026</div>
-        <div class="last-updated">Última actualización: <span id="updated"></span></div>
-      </header>
+    <section class="insights-section">
+      <h2>Insights</h2>
+      <div class="insights-grid" id="insightsGrid"></div>
+    </section>
 
-      <section id="kpis" class="stats-grid">
-        <div class="stat-card stat-card--cyan">
-          <span class="stat-card-icon">📅</span>
-          <div class="stat-number" id="totalDias">0</div>
-          <div class="stat-label">Días registrados</div>
-        </div>
-        <div class="stat-card stat-card--green">
-          <span class="stat-card-icon">✅</span>
-          <div class="stat-number verde" id="diasCumplimiento">0</div>
-          <div class="stat-label">Cumplimiento total</div>
-        </div>
-        <div class="stat-card stat-card--purple">
-          <span class="stat-card-icon">🏋️</span>
-          <div class="stat-number" id="diasEjercicio">0</div>
-          <div class="stat-label">Días con ejercicio</div>
-        </div>
-        <div class="stat-card stat-card--teal">
-          <span class="stat-card-icon">👟</span>
-          <div class="stat-number" id="diasPasos">0</div>
-          <div class="stat-label">Días con 10k+ pasos</div>
-        </div>
-        <div class="stat-card stat-card--cyan">
-          <span class="stat-card-icon">📊</span>
-          <div class="stat-number" id="promedioPasos">0</div>
-          <div class="stat-label">Promedio de pasos</div>
-        </div>
-        <div class="stat-card stat-card--gold">
-          <span class="stat-card-icon">🏆</span>
-          <div class="stat-number verde" id="recordPasos">0</div>
-          <div class="stat-label">Récord de pasos</div>
-        </div>
-      </section>
+    <section class="racha-section">
+      <h2>Racha reciente</h2>
+      <div class="racha-cards" id="rachaCards"></div>
+    </section>
 
-      <section id="insights" class="insights-section">
-        <h2>Insights</h2>
-        <div class="insights-grid" id="insightsGrid"></div>
-      </section>
-
-      <section id="racha" class="racha-section">
-        <h2>Racha reciente</h2>
-        <div class="racha-cards" id="rachaCards"></div>
-      </section>
-
-      <section id="graficas" class="charts-section">
-        <div class="chart-container">
-          <h2>Historial de entrenamiento</h2>
-          <div id="heatmap"></div>
-          <div class="chart-legend">
-            <div class="legend-item">
-              <span class="legend-dot verde"></span>
-              <span>Entrenamiento y pasos 10k <em>(Jue/Vie: solo pasos 10k)</em></span>
-            </div>
-            <div class="legend-item">
-              <span class="legend-dot verde-bajo"></span>
-              <span>Solo entrenamiento o solo pasos</span>
-            </div>
-            <div class="legend-item">
-              <span class="legend-dot gris"></span>
-              <span>Sin metas / Sin registro</span>
-            </div>
+    <section class="charts-section">
+      <div class="chart-container">
+        <h2>Historial de entrenamiento</h2>
+        <div id="heatmap"></div>
+        <div class="chart-legend">
+          <div class="legend-item">
+            <span class="legend-dot verde"></span>
+            <span>Entrenamiento y pasos 10k <em>(Jue/Vie: solo pasos 10k)</em></span>
+          </div>
+          <div class="legend-item">
+            <span class="legend-dot verde-bajo"></span>
+            <span>Solo entrenamiento o solo pasos</span>
+          </div>
+          <div class="legend-item">
+            <span class="legend-dot gris"></span>
+            <span>Sin metas / Sin registro</span>
           </div>
         </div>
+      </div>
 
-        <div class="chart-container">
-          <h2>Distribución por disciplina</h2>
-          <canvas id="pieChart"></canvas>
+      <div class="chart-container">
+        <h2>Distribución por disciplina</h2>
+        <canvas id="pieChart"></canvas>
+      </div>
+
+      <div class="chart-container full-width">
+        <h2>Tendencia de pasos (Historial completo)</h2>
+        <canvas id="trendChart"></canvas>
+      </div>
+    </section>
+
+    <section class="weekly-summary-section">
+      <div class="weekly-header">
+        <h2>Resumen Semanal</h2>
+        <div class="weekly-goals-legend">
+          <span class="wgl-item wgl-fuerza">5 sesiones fuerza</span>
+          <span class="wgl-item wgl-cardio">3 sesiones cardio</span>
+          <span class="wgl-item wgl-pasos">10k pasos/día</span>
         </div>
+      </div>
+      <div id="thisWeekPanel" class="this-week-panel"></div>
+      <div id="weeklySummary" class="weekly-grid"></div>
+    </section>
 
-        <div class="chart-container full-width">
-          <h2>Tendencia de pasos (Historial completo)</h2>
-          <canvas id="trendChart"></canvas>
-        </div>
+    <section class="stats-detail">
+      <h2>Análisis por día de la semana</h2>
+      <table class="week-table">
+        <thead>
+          <tr>
+            <th>Día</th>
+            <th>Total registros</th>
+            <th>Con ejercicio</th>
+            <th>Con 10k+ pasos</th>
+          </tr>
+        </thead>
+        <tbody id="weekTable"></tbody>
+      </table>
+    </section>
 
-        <div class="chart-container full-width">
-          <h2>Análisis por día de la semana</h2>
-          <table class="week-table">
-            <thead>
-              <tr>
-                <th>Día</th>
-                <th>Total registros</th>
-                <th>Con ejercicio</th>
-                <th>Con 10k+ pasos</th>
-              </tr>
-            </thead>
-            <tbody id="weekTable"></tbody>
-          </table>
-        </div>
-      </section>
-
-      <section id="semanas" class="weekly-summary-section">
-        <div class="weekly-header">
-          <h2>Resumen Semanal</h2>
-          <div class="weekly-goals-legend">
-            <span class="wgl-item wgl-fuerza">5 sesiones fuerza</span>
-            <span class="wgl-item wgl-cardio">3 sesiones cardio</span>
-            <span class="wgl-item wgl-pasos">10k pasos/día</span>
-          </div>
-        </div>
-        <div id="thisWeekPanel" class="this-week-panel"></div>
-        <div id="weeklySummary" class="weekly-grid"></div>
-      </section>
-
-      <footer class="footer">
-        <p>Dashboard conectado a Notion • Actualizado automáticamente cada noche</p>
-      </footer>
-    </div>
+    <footer class="footer">
+      <p>Dashboard conectado a Notion • Actualizado automáticamente cada noche</p>
+    </footer>
   </div>
 
   <script src="js/main.js"></script>

--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -160,7 +160,6 @@ function renderThisWeek() {
   const fin    = new Date(semana.fin    + 'T00:00:00');
   const fmtD   = d => `${d.getDate()} ${MESES[d.getMonth()]}`;
 
-  // Días restantes en la semana (incluyendo hoy). Lun=7, Mar=6, ... Dom=1
   const posInWeek = (new Date().getDay() + 6) % 7;
   const remainingDays = 7 - posInWeek;
 
@@ -453,33 +452,5 @@ function renderInsights() {
     </div>`).join('');
 }
 
-function initSidebar() {
-  const sectionIds = ['kpis', 'insights', 'racha', 'graficas', 'semanas'];
-  const links = {};
-  sectionIds.forEach(id => {
-    const el = document.querySelector(`.sidebar-link[href="#${id}"]`);
-    if (el) links[id] = el;
-  });
-
-  if (!Object.keys(links).length) return;
-
-  const observer = new IntersectionObserver(entries => {
-    entries.forEach(entry => {
-      if (entry.isIntersecting) {
-        Object.values(links).forEach(l => l.classList.remove('active'));
-        if (links[entry.target.id]) links[entry.target.id].classList.add('active');
-      }
-    });
-  }, { rootMargin: '-15% 0px -75% 0px', threshold: 0 });
-
-  sectionIds.forEach(id => {
-    const el = document.getElementById(id);
-    if (el) observer.observe(el);
-  });
-}
-
 // Cargar datos al iniciar
-document.addEventListener('DOMContentLoaded', () => {
-  loadData();
-  initSidebar();
-});
+document.addEventListener('DOMContentLoaded', loadData);

--- a/docs/sw.js
+++ b/docs/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'bitacora-v11';
+const CACHE_NAME = 'bitacora-v12';
 
 const STATIC_ASSETS = [
   '/bitacora-entrenamiento/',


### PR DESCRIPTION
## Cambios

- **Revert rediseño (issue #8):** elimina sidebar de navegación, iconos y acentos de color en KPIs, `page-layout`, `dayChart` y `pie-row` — restaura el layout original
- **Conserva panel "Esta semana"** (`thisWeekPanel` + `renderThisWeek()`) agregado manualmente después del rediseño
- **Conserva cambio de horario** en el workflow: `0 19 * * *` (1 PM México)
- **Conserva scripts de backup** a Google Drive (`backup_notion.py`, `requirements-backup.txt`, `CLAUDE.md`)
- Service Worker bumpeado a `v12` para forzar recarga en todos los clientes

## Archivos modificados

| Archivo | Cambio |
|---|---|
| `docs/index.html` | Revertido a layout original sin sidebar |
| `docs/css/style.css` | Eliminados estilos de sidebar y variantes de KPI |
| `docs/js/main.js` | Eliminado `initSidebar()`, conservado `renderThisWeek()` |
| `docs/js/charts.js` | Eliminado `renderDayChart()` |
| `.github/workflows/update-data.yml` | Horario `0 19 * * *` (1 PM México) |
| `docs/sw.js` | Cache `bitacora-v12` |

https://claude.ai/code/session_01Fwz2xdQdELWT3QUGh7gKZF

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fwz2xdQdELWT3QUGh7gKZF)_