### PR TITLE
Refactor weekly summary to show all months and remove "this week" panel

### DIFF
--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -822,6 +822,12 @@ canvas {
   box-shadow: 0 0 16px rgba(38, 166, 65, 0.1);
 }
 
+.month-card--future {
+  opacity: 0.3;
+  filter: saturate(0.2);
+  pointer-events: none;
+}
+
 .month-record-badge {
   font-size: 0.6em;
   font-weight: 700;

--- a/docs/index.html
+++ b/docs/index.html
@@ -110,7 +110,6 @@
           <span class="wgl-item wgl-pasos">10k pasos/día</span>
         </div>
       </div>
-      <div id="thisWeekPanel" class="this-week-panel"></div>
       <div id="weeklySummary" class="weekly-grid"></div>
     </section>
 

--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -56,9 +56,6 @@ function renderDashboard() {
   // Racha reciente
   renderRachas();
 
-  // Panel "¿Qué falta esta semana?"
-  renderThisWeek();
-
   // Resumen semanal
   renderWeeklySummary();
 
@@ -219,38 +216,13 @@ function renderWeeklySummary() {
   const CARDIO_DISC  = ['Natación', 'Carrera', 'Bici'];
   const COLOR_ESTADO = { verde: '#26a641', amarillo: '#006d32', rojo: '#1e293b', gris: '#1e293b' };
 
-  const hoy = new Date();
-  const hoyStr      = hoy.toISOString().split('T')[0];
-  const mesActual   = hoy.getFullYear() + '-' + String(hoy.getMonth() + 1).padStart(2, '0');
-  const inicioMes   = mesActual + '-01';
-  const finMes      = new Date(hoy.getFullYear(), hoy.getMonth() + 1, 0).toISOString().split('T')[0];
+  const hoy       = new Date();
+  const hoyStr    = hoy.toISOString().split('T')[0];
+  const mesActual = hoy.getFullYear() + '-' + String(hoy.getMonth() + 1).padStart(2, '0');
 
-  // Solo semanas del mes actual, de más nueva a más antigua
-  const semanasDelMes = [...dashboardData.semanas]
-    .filter(s => s.fin >= inicioMes && s.inicio <= finMes && !s.esSemanaActual)
-    .reverse();
+  // ── Tarjeta semana actual ─────────────────────────────────
+  const semanaActual = dashboardData.semanas.find(s => s.esSemanaActual);
 
-  // Agrupar días pasados por mes
-  const porMes = {};
-  (dashboardData.todosDatos || []).forEach(dia => {
-    const mes = dia.fecha.substring(0, 7);
-    if (mes >= mesActual) return;
-    if (!porMes[mes]) porMes[mes] = [];
-    porMes[mes].push(dia);
-  });
-
-  const mesesPasados = Object.keys(porMes).sort().reverse().map(mesKey => {
-    const dias = porMes[mesKey];
-    const [y, m] = mesKey.split('-');
-    return {
-      label:        `${MESES_NOMBRE[parseInt(m) - 1]} ${y}`,
-      diasFuerza:   dias.filter(d => d.disciplinas.includes('Fuerza')   || d.disciplinas.includes('Mixto')).length,
-      diasNatacion: dias.filter(d => d.disciplinas.some(disc => CARDIO_DISC.includes(disc)) || d.disciplinas.includes('Mixto')).length,
-      diasPasos:    dias.filter(d => d.cumplePasos).length,
-    };
-  });
-
-  // ── Tarjeta semanal ───────────────────────────────────────
   function weekCard(semana) {
     const inicio = new Date(semana.inicio + 'T00:00:00');
     const fin    = new Date(semana.fin    + 'T00:00:00');
@@ -306,7 +278,7 @@ function renderWeeklySummary() {
     }).join('');
 
     return `
-      <div class="week-card${semana.esSemanaActual ? ' week-card--current' : ''}">
+      <div class="week-card week-card--current">
         <div class="week-card-header">
           <span class="week-range">${label}</span>
           <span class="week-status ${statusClass}">${statusLabel}</span>
@@ -320,16 +292,44 @@ function renderWeeklySummary() {
       </div>`;
   }
 
-  // Mes con mayor actividad total
-  const maxScore = mesesPasados.length
-    ? Math.max(...mesesPasados.map(m => m.diasFuerza + m.diasNatacion + m.diasPasos))
-    : 0;
+  // ── Todos los meses: Dic 2025 → Dic 2026 ─────────────────
+  const porMes = {};
+  (dashboardData.todosDatos || []).forEach(dia => {
+    const mes = dia.fecha.substring(0, 7);
+    if (!porMes[mes]) porMes[mes] = [];
+    porMes[mes].push(dia);
+  });
+
+  const todosLosMeses = [];
+  for (let y = 2025, m = 11; ; ) {
+    const mesKey = `${y}-${String(m + 1).padStart(2, '0')}`;
+    const dias   = porMes[mesKey] || [];
+    const isFuture = mesKey > mesActual;
+    todosLosMeses.push({
+      label:        `${MESES_NOMBRE[m]} ${y}`,
+      mesKey,
+      diasFuerza:   dias.filter(d => d.disciplinas.includes('Fuerza')   || d.disciplinas.includes('Mixto')).length,
+      diasNatacion: dias.filter(d => d.disciplinas.some(disc => CARDIO_DISC.includes(disc)) || d.disciplinas.includes('Mixto')).length,
+      diasPasos:    dias.filter(d => d.cumplePasos).length,
+      isFuture,
+    });
+    if (y === 2026 && m === 11) break;
+    m++;
+    if (m === 12) { m = 0; y++; }
+  }
+  todosLosMeses.reverse(); // más reciente primero
+
+  const maxScore = Math.max(
+    ...todosLosMeses.filter(mes => !mes.isFuture && mes.mesKey < mesActual)
+      .map(mes => mes.diasFuerza + mes.diasNatacion + mes.diasPasos),
+    0
+  );
 
   function monthCard(mes) {
-    const score = mes.diasFuerza + mes.diasNatacion + mes.diasPasos;
-    const esRecord = score === maxScore && maxScore > 0;
+    const score   = mes.diasFuerza + mes.diasNatacion + mes.diasPasos;
+    const esRecord = !mes.isFuture && mes.mesKey < mesActual && score === maxScore && maxScore > 0;
     return `
-      <div class="month-card${esRecord ? ' month-card--record' : ''}">
+      <div class="month-card${esRecord ? ' month-card--record' : ''}${mes.isFuture ? ' month-card--future' : ''}">
         <div class="month-card-title">
           ${mes.label}
           ${esRecord ? '<span class="month-record-badge">Récord</span>' : ''}
@@ -351,13 +351,12 @@ function renderWeeklySummary() {
       </div>`;
   }
 
-  const weeklyHTML  = semanasDelMes.map(weekCard).join('');
-  const monthlyHTML = mesesPasados.length
-    ? `<div class="monthly-section">
-        <div class="monthly-section-title">Meses anteriores</div>
-        <div class="monthly-grid">${mesesPasados.map(monthCard).join('')}</div>
-       </div>`
-    : '';
+  const weeklyHTML  = semanaActual ? weekCard(semanaActual) : '';
+  const monthlyHTML = `
+    <div class="monthly-section">
+      <div class="monthly-section-title">Meses</div>
+      <div class="monthly-grid">${todosLosMeses.map(monthCard).join('')}</div>
+    </div>`;
 
   container.innerHTML = weeklyHTML + monthlyHTML;
 }

--- a/docs/sw.js
+++ b/docs/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'bitacora-v15';
+const CACHE_NAME = 'bitacora-v16';
 
 const STATIC_ASSETS = [
   '/bitacora-entrenamiento/',


### PR DESCRIPTION
## Summary
This PR refactors the dashboard's weekly summary section to display a comprehensive view of all months (December 2025 through December 2026) instead of just the current month's weeks, and removes the separate "¿Qué falta esta semana?" panel.

## Key Changes

- **Removed `renderThisWeek()` function call** from the main dashboard render flow
- **Removed "thisWeekPanel" HTML element** from the index.html template
- **Refactored `renderWeeklySummary()` to:**
  - Display only the current week card (instead of multiple weeks from the current month)
  - Generate a complete 13-month view (Dec 2025 → Dec 2026) with all available data
  - Replace "Meses anteriores" section title with just "Meses"
  - Always show the monthly grid (previously conditional)
  
- **Added visual styling for future months:**
  - New `.month-card--future` CSS class with reduced opacity (0.3) and desaturated colors
  - Future months are marked as non-interactive (`pointer-events: none`)
  
- **Updated cache version** from v15 to v16 in service worker

## Implementation Details

- The month generation logic now iterates through a fixed 13-month range rather than filtering based on current month boundaries
- Future months (those after the current month) are identified via the `isFuture` flag and styled distinctly
- Record badge calculation now explicitly excludes future months to prevent false positives
- Week card styling simplified to always apply the `week-card--current` class since only the current week is displayed

https://claude.ai/code/session_01Fwz2xdQdELWT3QUGh7gKZF