### PR TITLE
ci: pause scheduled workflow until Drive OAuth token is renewed

### DIFF
--- a/.github/workflows/update-data.yml
+++ b/.github/workflows/update-data.yml
@@ -1,10 +1,7 @@
 name: Update Training Data
 
 on:
-  schedule:
-    # Ejecuta todos los días a la 1:00 PM hora México (UTC-6 = 19:00 UTC)
-    - cron: '0 19 * * *'
-  workflow_dispatch:  # Permite ejecución manual
+  workflow_dispatch:  # Solo manual mientras se renueva el token de Drive
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true


### PR DESCRIPTION
## Summary

- Removes the `schedule` cron trigger from `update-data.yml`
- Workflow now only runs manually via `workflow_dispatch`
- The daily job was failing with `invalid_grant` because the Google Drive OAuth refresh token expired

## To re-enable

1. Run `scripts/generar_token_drive.py` locally to get a fresh `token.json`
2. Update the `GOOGLE_CREDENTIALS` secret in GitHub repository settings
3. Add back the `schedule` trigger:
   ```yaml
   schedule:
     - cron: '0 19 * * *'
   ```

https://claude.ai/code/session_01Fwz2xdQdELWT3QUGh7gKZF

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fwz2xdQdELWT3QUGh7gKZF)_